### PR TITLE
Preingest+ingest concept (METS->YAML, YAML ingest)

### DIFF
--- a/app/jobs/ingest_yaml_job.rb
+++ b/app/jobs/ingest_yaml_job.rb
@@ -1,0 +1,116 @@
+class IngestYAMLJob < ActiveJob::Base
+  queue_as :ingest
+
+  # @param [String] yaml_file Filename of a YAML file to ingest
+  # @param [String] user User to ingest as
+  # @param [Array<String>] collections Collection IDs the resources should be members of
+  def perform(yaml_file, user, collections = [])
+    logger.info "Ingesting YAML #{yaml_file}"
+    @yaml_file = yaml_file
+    @yaml = File.open(yaml_file) { |f| Psych.load(f) }
+    @user = user
+    @collections = collections.map { |col_id| Collection.find(col_id) }
+
+    ingest
+  end
+
+  private
+
+    def ingest
+      resource = minimal_record(@yaml[:volumes].present? ? MultiVolumeWork : ScannedResource)
+      resource.identifier = @yaml[:identifier]
+      resource.replaces = @yaml[:replaces]
+      resource.source_metadata_identifier = @yaml[:source_metadata_identifier]
+      resource.member_of_collections = @collections
+      resource.apply_remote_metadata
+      resource.save!
+      logger.info "Created #{resource.class}: #{resource.id}"
+
+      attach_sources resource
+
+      if @yaml[:volumes].present?
+        ingest_volumes(resource)
+      else
+        ingest_files(resource: resource, files: @yaml[:files])
+        if @yaml[:structure].present?
+          resource.logical_order.order = map_fileids(@yaml[:structure])
+        end
+        resource.save!
+      end
+    end
+
+    def attach_sources(resource)
+      attach_source(resource, ['YAML'], @yaml_file)
+      return unless @yaml[:source].present?
+      attach_source(resource, @yaml[:source][:title], @yaml[:source][:file])
+    end
+
+    def attach_source(resource, title, file)
+      file_set = FileSet.new
+      file_set.title = title
+      actor = FileSetActor.new(file_set, @user)
+      actor.attach_related_object(resource)
+      actor.attach_content(File.open(file, 'r:UTF-8'))
+    end
+
+    def minimal_record(klass)
+      resource = klass.new
+      resource.state = 'final_review'
+      resource.viewing_direction = @yaml[:viewing_direction]
+      resource.rights_statement = 'http://rightsstatements.org/vocab/NKC/1.0/'
+      resource.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      resource.apply_depositor_metadata @user
+      resource
+    end
+
+    def ingest_volumes(parent)
+      @yaml[:volumes].each do |volume|
+        r = minimal_record(ScannedResource)
+        r.title = volume[:title]
+        r.save!
+        logger.info "Created ScannedResource: #{r.id}"
+
+        ingest_files(parent: parent, resource: r, files: volume[:files])
+        r.logical_order.order = map_fileids(volume[:structure])
+        r.save!
+
+        parent.ordered_members << r
+        parent.save!
+      end
+    end
+
+    def ingest_files(parent: nil, resource: nil, files: [])
+      files.each do |f|
+        logger.info "Ingesting file #{f[:path]}"
+        file_set = FileSet.new
+        file_set.title = f[:title]
+        file_set.replaces = f[:replaces]
+        actor = FileSetActor.new(file_set, @user)
+        actor.create_metadata(resource, f[:file_opts])
+        actor.create_content(decorated_file(f))
+
+        mets_to_repo_map[f[:id]] = file_set.id
+
+        next unless f[:path] == @yaml[:thumbnail_path]
+        resource.thumbnail_id = file_set.id
+        resource.save!
+        parent.thumbnail_id = file_set.id if parent
+      end
+    end
+
+    # unmodified copied methods
+    def decorated_file(f)
+      IoDecorator.new(File.open(f[:path]), f[:mime_type], File.basename(f[:path]))
+    end
+
+    def map_fileids(hsh)
+      hsh.each do |k, v|
+        hsh[k] = v.each { |node| map_fileids(node) } if k == :nodes
+        hsh[k] = mets_to_repo_map[v] if k == :proxy
+      end
+    end
+
+    def mets_to_repo_map
+      @mets_to_repo_map ||= {}
+    end
+end

--- a/app/jobs/preingest_mets_job.rb
+++ b/app/jobs/preingest_mets_job.rb
@@ -1,0 +1,58 @@
+class PreingestMETSJob < ActiveJob::Base
+  queue_as :preingest
+
+  # @param [String] mets_file Filename of a METS file to ingest
+  # @param [String] user User to ingest as
+  # @param [Array<String>] collections Collection IDs the resources should be members of
+  def perform(mets_file, user, collections = [])
+    logger.info "Preingesting METS #{mets_file}"
+    @mets = METSDocument.new mets_file
+    @user = user
+    @collections = collections.map { |col_id| Collection.find(col_id) }
+
+    preingest
+  end
+
+  private
+
+    def preingest
+      yaml_hash = {}
+      { identifier: :ark_id,
+        replaces: :pudl_id,
+        source_metadata_identifier: :bib_id,
+        viewing_direction: :viewing_direction,
+        thumbnail_path: :thumbnail_path
+      }.each do |att, mets_method|
+        yaml_hash[att] = @mets.send(mets_method)
+      end
+      if @mets.multi_volume?
+        yaml_hash[:volumes] = []
+        @mets.volume_ids.each do |volume_id|
+          volume_hash = {}
+          volume_hash[:id] = volume_id
+          volume_hash[:title] = [@mets.label_for_volume(volume_id)]
+          volume_hash[:structure] = @mets.structure_for_volume(volume_id)
+          volume_hash[:files] = add_file_attributes(@mets.files_for_volume(volume_id))
+          yaml_hash[:volumes] << volume_hash
+        end
+      else
+        yaml_hash[:structure] = @mets.structure
+        yaml_hash[:files] = add_file_attributes(@mets.files)
+      end
+      yaml_hash[:source] = {}
+      yaml_hash[:source][:title] = ['METS XML']
+      yaml_hash[:source][:file] = @mets.source_file
+      yaml_file = @mets.source_file.sub(/\.mets$/, '.yml')
+      File.write(yaml_file, yaml_hash.to_yaml)
+      logger.info "Created YAML file #{File.basename(yaml_file)}"
+    end
+
+    def add_file_attributes(file_hash_array)
+      file_hash_array.each do |f|
+        f[:title] = [@mets.file_label(f[:id])]
+        f[:replaces] = "#{@mets.pudl_id}/#{File.basename(f[:path], File.extname(f[:path]))}"
+        f[:file_opts] = @mets.file_opts(f)
+      end
+      file_hash_array
+    end
+end

--- a/lib/tasks/ingest_yaml.rake
+++ b/lib/tasks/ingest_yaml.rake
@@ -1,0 +1,21 @@
+desc "Ingest one or more YAML files"
+task ingest_yaml: :environment do
+  user = User.find_by_user_key( ENV['USER'] ) if ENV['USER']
+  user = User.all.select{ |u| u.admin? }.first unless user
+
+  collections = (ENV['COLLECTIONS'] || "").split(" ")
+
+  logger = Logger.new(STDOUT)
+  IngestYAMLJob.logger = logger
+  logger.info "ingesting .yml files from: #{ARGV[1]}"
+  logger.info "ingesting as: #{user.user_key} (override with USER=foo)"
+  abort "usage: rake ingest_yaml /path/to/yaml/files" unless ARGV[1] && Dir.exist?(ARGV[1])
+  Dir["#{ARGV[1]}/**/*.yml"].each do |file|
+    begin
+      IngestYAMLJob.perform_now(file, user, collections)
+    rescue => e
+      puts "Error: #{e.message}"
+      puts e.backtrace
+    end
+  end
+end

--- a/lib/tasks/preingest_mets.rake
+++ b/lib/tasks/preingest_mets.rake
@@ -1,0 +1,21 @@
+desc "Preingest one or more METS files"
+task preingest_mets: :environment do
+  user = User.find_by_user_key( ENV['USER'] ) if ENV['USER']
+  user = User.all.select{ |u| u.admin? }.first unless user
+
+  collections = (ENV['COLLECTIONS'] || "").split(" ")
+
+  logger = Logger.new(STDOUT)
+  PreingestMETSJob.logger = logger
+  logger.info "preingesting mets files from: #{ARGV[1]}"
+  logger.info "preingesting as: #{user.user_key} (override with USER=foo)"
+  abort "usage: rake ingest_mets /path/to/mets/files" unless ARGV[1] && Dir.exist?(ARGV[1])
+  Dir["#{ARGV[1]}/**/*.mets"].each do |file|
+    begin
+      PreingestMETSJob.perform_now(file, user, collections)
+    rescue => e
+      puts "Error: #{e.message}"
+      puts e.backtrace
+    end
+  end
+end

--- a/spec/fixtures/pudl_mets/pudl0001-4609321-s42.mets
+++ b/spec/fixtures/pudl_mets/pudl0001-4609321-s42.mets
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="ark:/88435/7d278t10z" TYPE="CompiledDigitalObject" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd">
+  <mets:metsHdr CREATEDATE="2016-03-14T15:21:33.372-04:00" LASTMODDATE="2016-03-14T15:21:33.372-04:00">
+    <mets:metsDocumentID TYPE="PUDL">pudl0001/4609321/s42.mets</mets:metsDocumentID>
+  </mets:metsHdr>
+  <mets:dmdSec ID="x6kkx">
+    <mets:mdRef LOCTYPE="URL" MDTYPE="MARC" xlink:href="https://bibdata.princeton.edu/bibliographic/bhr9405"/>
+  </mets:dmdSec>
+  <mets:dmdSec ID="p0ov5">
+    <mets:mdWrap MDTYPE="MODS">
+      <mets:xmlData>
+        <mods xmlns="http://www.loc.gov/mods/v3" version="3.3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
+          <titleInfo>
+            <title>Biblia Latina</title>
+          </titleInfo>
+          <titleInfo type="alternative">
+            <title>Gutenberg Bible</title>
+          </titleInfo>
+          <titleInfo type="alternative">
+            <title>Mazarin Bible</title>
+          </titleInfo>
+          <titleInfo type="alternative">
+            <title>Mazarine Bible</title>
+          </titleInfo>
+          <titleInfo type="uniform">
+            <title>Bible. Latin. 1456</title>
+          </titleInfo>
+          <name authority="naf" type="personal">
+            <namePart type="family">Gutenberg</namePart>
+            <namePart type="given">Johann</namePart>
+            <namePart type="date">1397?-1468</namePart>
+            <role>
+              <roleTerm authority="marcrelator" type="code">prt</roleTerm>
+            </role>
+          </name>
+          <name authority="naf" type="personal">
+            <namePart type="given">Master of the Playing Cards</namePart>
+            <namePart type="date">15th cent</namePart>
+            <role>
+              <roleTerm authority="marcrelator" type="code">ilu</roleTerm>
+            </role>
+          </name>
+          <name authority="naf" type="personal">
+            <namePart type="family">Fogel, Johannes</namePart>
+            <namePart type="given">Johannes</namePart>
+            <namePart type="date">fl. 1455-1462</namePart>
+            <role>
+              <roleTerm authority="marcrelator" type="code">bnd</roleTerm>
+            </role>
+          </name>
+          <typeOfResource>text</typeOfResource>
+          <originInfo>
+            <place>
+              <placeTerm type="text">Mainz</placeTerm>
+            </place>
+            <publisher>Printer of the 42-line Bible (Johann Gutenberg?)</publisher>
+            <dateOther type="display">before August 1456</dateOther>
+            <dateIssued encoding="w3cdtf" keyDate="yes">1456</dateIssued>
+          </originInfo>
+          <language>
+            <languageTerm authority="iso639-2b" type="code">lat</languageTerm>
+          </language>
+          <physicalDescription>
+            <form authority="marcform">print</form>
+            <extent>2 v. (324; 319 leaves) ; 40.5 × 28.8 cm. (fol.)</extent>
+          </physicalDescription>
+          <note>Commonly known in English as Gutenberg Bible, formerly known as Mazarin or Mazarine Bible.</note>
+          <note>Twelve leaves supplied from other copies and 5 leaves supplied in facsimile; the 17 leaves are vol. I fo. 1 and vol. II fo. 1, 17,
+      25, 46, 70, 149, 155, 156, 191, 217, 235, 268, 270, 275, 279, and 305.</note>
+          <note>Illuminated by Master of the Playing Cards.</note>
+          <note type="provenance">Predigerkirche, Erfurt, Germany; A. Cohn; Asher and Company; Henry Stevens; George Brinley; Brayton Ives; George
+      Hamilton Cole; and James W. Ellsworth; acquired 2/11/24 from Rosenbach; 2 ff. 11/22/34, Rosenbach; 10 ff. 6/21/37, Rosenbach.
+      NjP</note>
+          <relatedItem type="isReferencedBy">
+            <note>Stillwell B460</note>
+          </relatedItem>
+          <relatedItem type="isReferencedBy">
+            <note>Goff B-526</note>
+          </relatedItem>
+          <relatedItem type="host">
+            <titleInfo>
+              <title>Scheide Library</title>
+              <subTitle>Fifteenth-Century Printing</subTitle>
+            </titleInfo>
+            <location>
+              <url note="Digital collection">http://arks.princeton.edu/ark:/88435/xp68kg247</url>
+            </location>
+          </relatedItem>
+          <accessCondition type="useAndReproduction" xlink:href="http://www.princeton.edu/~rbsc/research/rights.html">Use and
+      reproduction</accessCondition>
+          <accessCondition type="restrictionOnAccess" xlink:href="http://www.princeton.edu/~rbsc/research/rules.html">Restrictions on
+      access</accessCondition>
+          <identifier type="local">4609321</identifier>
+          <location>
+            <physicalLocation type="text">Princeton University. Scheide Library.</physicalLocation>
+            <physicalLocation authority="marcorg" type="code">NjP</physicalLocation>
+            <holdingSimple>
+              <copyInformation>
+                <subLocation>whs</subLocation>
+                <shelfLocator>S4.2</shelfLocator>
+              </copyInformation>
+            </holdingSimple>
+          </location>
+          <recordInfo>
+            <recordContentSource authority="marcorg">NjP</recordContentSource>
+            <recordOrigin>http://catalog.princeton.edu/cgi-bin/Pwebrecon.cgi?BBID=4609321</recordOrigin>
+            <recordIdentifier>http://diglib.princeton.edu/mdata/pudl0001/4609321/s42.mods</recordIdentifier>
+          </recordInfo>
+        </mods>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:fileSec>
+    <mets:fileGrp USE="thumbnail">
+      <mets:file ID="co69n" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/pudl0001/4612596/00000001.tif"/>
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="masters">
+      <mets:file CHECKSUM="33a5b539e3d1f9abbda59776149d57740d9e7788" CHECKSUMTYPE="SHA-1" ID="gylme" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/pudl0001/4612596/00000001.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="94b8bb21d88a05519be035077ca8e2fcf24b62ce" CHECKSUMTYPE="SHA-1" ID="l898s" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/pudl0001/4612596/00000002.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="5ff6c95e931d3b71cbaff41c3d1b994390ba44c1" CHECKSUMTYPE="SHA-1" ID="itc6o" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/pudl0001/4612596/00000003.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="adc66d858b1efe8cb376ad9c021ff9af4dfb7475" CHECKSUMTYPE="SHA-1" ID="tp8n6" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/pudl0001/4612596/00000657.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="ce773c29f10ad4c08dabe85c69ac0f385b65f0a8" CHECKSUMTYPE="SHA-1" ID="l4e90" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/pudl0001/4612596/00000658.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="4e3003e04f6ddba5f1a31064085e6a1a0b18a559" CHECKSUMTYPE="SHA-1" ID="ivg04" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/pudl0001/4612596/00000659.tif"/>
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap TYPE="RelatedObjects">
+    <mets:div DMDID="x6kkx p0ov5" ID="o64yj" LABEL="Default">
+      <mets:div CONTENTIDS="pudl0001" TYPE="IsPartOf"/>
+      <mets:div ID="aggregates" TYPE="OrderedList">
+        <mets:div ID="a5z8u" LABEL="vol. 1, upper cover" ORDER="1" TYPE="Static">
+          <mets:fptr FILEID="gylme"/>
+        </mets:div>
+        <mets:div ID="bkqa7" LABEL="vol. 1, upper pastedown" ORDER="2" TYPE="Static">
+          <mets:fptr FILEID="l898s"/>
+        </mets:div>
+        <mets:div ID="gezxb" LABEL="vol. 1, leaf 1r, gathering 1/1" ORDER="3" TYPE="Static">
+          <mets:fptr FILEID="itc6o"/>
+        </mets:div>
+        <mets:div ID="x8npn" LABEL="vol. 2, upper pastedown" ORDER="2" TYPE="Static">
+          <mets:fptr FILEID="tp8n6"/>
+        </mets:div>
+        <mets:div ID="xm7tw" LABEL="vol. 2, leaf 1r, gathering 1/1" ORDER="3" TYPE="Static">
+          <mets:fptr FILEID="l4e90"/>
+        </mets:div>
+        <mets:div ID="xjv77" LABEL="vol. 2, leaf 1v" ORDER="4" TYPE="Static">
+          <mets:fptr FILEID="ivg04"/>
+        </mets:div>
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+  <mets:structMap TYPE="Physical">
+    <mets:div ID="tu1zb" TYPE="MultiVolumeSet">
+      <mets:div ID="phys1" LABEL="first volume" TYPE="BoundVolume">
+        <mets:div ID="xsu9k" LABEL="upper cover" TYPE="UpperCover">
+          <mets:div ID="uel37" LABEL="cover" ORDER="1" TYPE="CoverOutside">
+            <mets:fptr FILEID="gylme"/>
+          </mets:div>
+          <mets:div ID="y9sd8" LABEL="pastedown" ORDER="2" TYPE="Pastedown">
+            <mets:fptr FILEID="l898s"/>
+          </mets:div>
+        </mets:div>
+        <mets:div ID="sj69e" LABEL="gathering 1" TYPE="Gathering">
+          <mets:div ID="w19h0" LABEL="leaf 1, gathering 1/1" TYPE="Leaf">
+            <mets:div ID="tjppa" LABEL="recto" ORDER="3" TYPE="Side">
+              <mets:fptr FILEID="itc6o"/>
+            </mets:div>
+          </mets:div>
+        </mets:div>
+      </mets:div>
+      <mets:div ID="phys2" LABEL="second volume" TYPE="BoundVolume">
+        <mets:div ID="cd0nv" LABEL="upper cover" TYPE="UpperCover">
+          <mets:div ID="wdrhr" LABEL="pastedown" ORDER="2" TYPE="Pastedown">
+            <mets:fptr FILEID="tp8n6"/>
+          </mets:div>
+        </mets:div>
+        <mets:div ID="hresd" LABEL="gathering 1" TYPE="Gathering">
+          <mets:div ID="jvt8x" LABEL="leaf 1, gathering 1/1" TYPE="Leaf">
+            <mets:div ID="yx262" LABEL="recto" ORDER="3" TYPE="Side">
+              <mets:fptr FILEID="l4e90"/>
+            </mets:div>
+            <mets:div ID="sz6nc" LABEL="verso" ORDER="4" TYPE="Side">
+              <mets:fptr FILEID="ivg04"/>
+            </mets:div>
+          </mets:div>
+        </mets:div>
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+  <mets:structLink>
+    <mets:smLink xlink:from="phys1" xlink:to=""/>
+    <mets:smLink xlink:from="phys2" xlink:to=""/>
+  </mets:structLink>
+</mets:mets>

--- a/spec/fixtures/pudl_mets/pudl0001-4609321-s42.yml
+++ b/spec/fixtures/pudl_mets/pudl0001-4609321-s42.yml
@@ -1,0 +1,95 @@
+---
+:identifier: ark:/88435/7d278t10z
+:replaces: pudl0001/4609321/s42
+:source_metadata_identifier: bhr9405
+:viewing_direction: left-to-right
+:thumbnail_path: "/tmp/pudl0001/4612596/00000001.tif"
+:volumes:
+- :id: phys1
+  :title:
+  - first volume
+  :structure:
+    :nodes:
+    - :label: upper cover
+      :nodes:
+      - :label: upper cover. cover
+        :proxy: gylme
+      - :label: upper cover. pastedown
+        :proxy: l898s
+    - :label: gathering 1
+      :nodes:
+      - :label: leaf 1, gathering 1/1
+        :nodes:
+        - :label: gathering 1. leaf 1, gathering 1/1. recto
+          :proxy: itc6o
+  :files:
+  - :id: gylme
+    :checksum: 33a5b539e3d1f9abbda59776149d57740d9e7788
+    :mime_type: image/tiff
+    :path: "/tmp/pudl0001/4612596/00000001.tif"
+    :title:
+    - upper cover. cover
+    :replaces: pudl0001/4609321/s42/00000001
+    :file_opts: {}
+  - :id: l898s
+    :checksum: 94b8bb21d88a05519be035077ca8e2fcf24b62ce
+    :mime_type: image/tiff
+    :path: "/tmp/pudl0001/4612596/00000002.tif"
+    :title:
+    - upper cover. pastedown
+    :replaces: pudl0001/4609321/s42/00000002
+    :file_opts: {}
+  - :id: itc6o
+    :checksum: 5ff6c95e931d3b71cbaff41c3d1b994390ba44c1
+    :mime_type: image/tiff
+    :path: "/tmp/pudl0001/4612596/00000003.tif"
+    :title:
+    - gathering 1. leaf 1, gathering 1/1. recto
+    :replaces: pudl0001/4609321/s42/00000003
+    :file_opts: {}
+- :id: phys2
+  :title:
+  - second volume
+  :structure:
+    :nodes:
+    - :label: upper cover
+      :nodes:
+      - :label: upper cover. pastedown
+        :proxy: tp8n6
+    - :label: gathering 1
+      :nodes:
+      - :label: leaf 1, gathering 1/1
+        :nodes:
+        - :label: gathering 1. leaf 1, gathering 1/1. recto
+          :proxy: l4e90
+        - :label: gathering 1. leaf 1, gathering 1/1. verso
+          :proxy: ivg04
+  :files:
+  - :id: tp8n6
+    :checksum: adc66d858b1efe8cb376ad9c021ff9af4dfb7475
+    :mime_type: image/tiff
+    :path: "/tmp/pudl0001/4612596/00000657.tif"
+    :title:
+    - upper cover. pastedown
+    :replaces: pudl0001/4609321/s42/00000657
+    :file_opts: {}
+  - :id: l4e90
+    :checksum: ce773c29f10ad4c08dabe85c69ac0f385b65f0a8
+    :mime_type: image/tiff
+    :path: "/tmp/pudl0001/4612596/00000658.tif"
+    :title:
+    - gathering 1. leaf 1, gathering 1/1. recto
+    :replaces: pudl0001/4609321/s42/00000658
+    :file_opts: {}
+  - :id: ivg04
+    :checksum: 4e3003e04f6ddba5f1a31064085e6a1a0b18a559
+    :mime_type: image/tiff
+    :path: "/tmp/pudl0001/4612596/00000659.tif"
+    :title:
+    - gathering 1. leaf 1, gathering 1/1. verso
+    :replaces: pudl0001/4609321/s42/00000659
+    :file_opts: {}
+:source:
+  :title:
+  - METS XML
+  :file: spec/fixtures/pudl_mets/pudl0001-4609321-s42.mets

--- a/spec/fixtures/pudl_mets/pudl0001-4612596.mets
+++ b/spec/fixtures/pudl_mets/pudl0001-4612596.mets
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="ark:/88435/5m60qr98h" TYPE="CompiledDigitalObject" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd">
+  <mets:metsHdr CREATEDATE="2016-03-14T15:21:34.002-04:00" LASTMODDATE="2016-03-14T15:21:34.002-04:00">
+    <mets:metsDocumentID TYPE="PUDL">pudl0001/4612596.mets</mets:metsDocumentID>
+  </mets:metsHdr>
+  <mets:dmdSec ID="p7p3g">
+    <mets:mdRef LOCTYPE="URL" MDTYPE="MARC" xlink:href="https://bibdata.princeton.edu/bibliographic/bhr9405"/>
+  </mets:dmdSec>
+  <mets:dmdSec ID="mfyt6">
+    <mets:mdWrap MDTYPE="MODS">
+      <mets:xmlData>
+        <mods xmlns="http://www.loc.gov/mods/v3" version="3.3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
+          <titleInfo>
+            <title>Ars minor [fragment]</title>
+          </titleInfo>
+          <name authority="lcnaf" type="personal">
+            <namePart>Donatus, Aelius</namePart>
+            <role>
+              <roleTerm authority="marcrelator" type="code">cre</roleTerm>
+            </role>
+          </name>
+          <!--<name type="corporate"><namePart>Maggs Bros</namePart><role><roleTerm type="text">bookseller</roleTerm>
+         </role></name>-->
+          <typeOfResource>text</typeOfResource>
+          <originInfo>
+            <place>
+              <placeTerm type="text">[Netherlands</placeTerm>
+            </place>
+            <publisher>Prototypography (Type 5: Saliceto Type)</publisher>
+            <dateOther>ca. 1470-1475?]</dateOther>
+            <dateIssued encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">1470</dateIssued>
+            <dateIssued encoding="w3cdtf" point="end" qualifier="approximate">1475</dateIssued>
+          </originInfo>
+          <abstract>Although printed with the same type as the Scheide fragment Goff D-325a, this fragment clearly belongs
+             to a different edition, for the closing text on fo. 2v of the former fragment does not match up with the
+             beginning text on fo. 3r of the present fragment. In the present fragment, some early bookbinder cut away
+             the first three lines of text.</abstract>
+          <language>
+            <languageTerm authority="iso639-2b" type="code">lat</languageTerm>
+          </language>
+          <physicalDescription>
+            <extent>1 incomplete bifolium; 15.4 × 20.6 cm</extent>
+          </physicalDescription>
+          <note type="physicalDetails">1 incomplete bifolium (fos. 2.7, Schwenke 6:1-9:6; 10:2-12:5; 22:1-23:21; 24:2-36)
+             of a 27-line edition in 14 leaves, printed with the Prototypography Saliceto type. Printed on vellum. Rubricated.
+            </note>
+          <note type="acquisition">Purchased by John H. Scheide at Sotheby’s, 25 July 1938, lot 166</note>
+          <subject authority="lcsh">
+            <topic>Latin language</topic>
+            <topic>Grammar</topic>
+            <genre>Early works to 1500</genre>
+          </subject>
+          <subject authority="lcsh">
+            <topic>Type and type-founding</topic>
+            <topic>Specimens</topic>
+          </subject>
+          <relatedItem type="isReferencedBy">
+            <note>GW 8749/10</note>
+          </relatedItem>
+          <relatedItem type="isReferencedBy">
+            <note>Goff D-322a</note>
+          </relatedItem>
+          <relatedItem type="isReferencedBy">
+            <note>ILC 766</note>
+          </relatedItem>
+          <relatedItem type="isReferencedBy">
+            <note>Invention and Early Spread of European Printing, no. 33</note>
+          </relatedItem>
+          <identifier type="local">4612596</identifier>
+          <location>
+            <physicalLocation type="text">Princeton University. Scheide Library.</physicalLocation>
+            <physicalLocation authority="marcorg" type="code">NjP</physicalLocation>
+            <holdingSimple>
+              <copyInformation>
+                <subLocation>whs</subLocation>
+                <shelfLocator>4.2.4</shelfLocator>
+              </copyInformation>
+            </holdingSimple>
+          </location>
+          <accessCondition type="useAndReproduction" xlink:href="http://www.princeton.edu/~rbsc/research/rights.html">Use and
+             reproduction</accessCondition>
+          <accessCondition type="restrictionOnAccess" xlink:href="http://www.princeton.edu/~rbsc/research/rules.html">Restrictions on
+             access</accessCondition>
+          <relatedItem type="host">
+            <titleInfo>
+              <title>Scheide Library</title>
+              <subTitle>Fifteenth-Century Printing</subTitle>
+            </titleInfo>
+            <location>
+              <url note="Digital collection">http://arks.princeton.edu/ark:/88435/xp68kg247</url>
+            </location>
+          </relatedItem>
+          <recordInfo>
+            <recordContentSource authority="marcorg">NjP</recordContentSource>
+            <recordOrigin>http://catalog.princeton.edu/cgi-bin/Pwebrecon.cgi?BBID=4612596</recordOrigin>
+            <recordIdentifier>http://diglib.princeton.edu/mdata/pudl0001/4612596.mods</recordIdentifier>
+          </recordInfo>
+        </mods>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:fileSec>
+    <mets:fileGrp USE="thumbnail">
+      <mets:file ID="vravt" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/pudl0001/4612596/00000001.tif"/>
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="masters">
+      <mets:file CHECKSUM="5b0ed4a62f96a19c5267fa8a9e1caf876c87e8d0" CHECKSUMTYPE="SHA-1" ID="pkc90" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/pudl0001/4612596/00000001.tif"/>
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap TYPE="RelatedObjects">
+    <mets:div DMDID="p7p3g mfyt6" ID="kxpde">
+      <mets:div CONTENTIDS="pudl0001" TYPE="IsPartOf"/>
+      <mets:div ID="aggregates" TYPE="OrderedList">
+        <mets:div ID="a6ubs" LABEL="recto" ORDER="1" TYPE="Static">
+          <mets:fptr FILEID="pkc90"/>
+        </mets:div>
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+  <mets:structMap TYPE="Physical">
+    <mets:div DMDID="p7p3g mfyt6" ID="pfgqm" TYPE="BoundVolume">
+      <mets:div ID="h8ib6" LABEL="leaf 1" TYPE="Leaf">
+        <mets:div ID="nhbtw" LABEL="recto" ORDER="1" TYPE="Page">
+          <mets:fptr FILEID="pkc90"/>
+        </mets:div>
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+  <mets:structMap TYPE="Logical">
+    <mets:div DMDID="p7p3g mfyt6" ID="pfgqm" TYPE="BoundVolume">
+      <mets:div ID="h8ib6" LABEL="leaf 1" TYPE="Leaf">
+        <mets:div ID="nhbtw" LABEL="recto" ORDER="1" TYPE="Page">
+          <mets:fptr FILEID="pkc90"/>
+        </mets:div>
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+</mets:mets>

--- a/spec/fixtures/pudl_mets/pudl0001-4612596.yml
+++ b/spec/fixtures/pudl_mets/pudl0001-4612596.yml
@@ -1,0 +1,25 @@
+---
+:identifier: ark:/88435/5m60qr98h
+:replaces: pudl0001/4612596
+:source_metadata_identifier: bhr9405
+:viewing_direction: left-to-right
+:thumbnail_path: "/tmp/pudl0001/4612596/00000001.tif"
+:structure:
+  :nodes:
+  - :label: leaf 1
+    :nodes:
+    - :label: leaf 1. recto
+      :proxy: pkc90
+:files:
+- :id: pkc90
+  :checksum: 5b0ed4a62f96a19c5267fa8a9e1caf876c87e8d0
+  :mime_type: image/tiff
+  :path: "/tmp/pudl0001/4612596/00000001.tif"
+  :title:
+  - leaf 1. recto
+  :replaces: pudl0001/4612596/00000001
+  :file_opts: {}
+:source:
+  :title:
+  - METS XML
+  :file: spec/fixtures/pudl_mets/pudl0001-4612596.mets

--- a/spec/fixtures/variations_mets/bhr9405.mets
+++ b/spec/fixtures/variations_mets/bhr9405.mets
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="ark:/88435/bv73c047c" TYPE="CompiledDigitalObject" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd">
+  <mets:metsHdr CREATEDATE="2016-03-14T14:24:54.358-04:00" LASTMODDATE="2016-03-14T14:24:54.358-04:00">
+    <mets:metsDocumentID TYPE="PUDL">pudl0032/ns73.mets</mets:metsDocumentID>
+  </mets:metsHdr>
+  <mets:dmdSec ID="mlys4">
+    <mets:mdRef LOCTYPE="URL" MDTYPE="MARC" xlink:href="https://dlib.indiana.edu/bibliographic/BHR9405"/>
+  </mets:dmdSec>
+  <mets:dmdSec ID="wvyxo">
+    <mets:mdWrap MDTYPE="MODS">
+      <mets:xmlData>
+      <mods xmlns="http://www.loc.gov/mods/v3" version="3.2"
+            schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-2.xsd">
+         <titleInfo>
+            <title>Fontane di Roma</title>
+            <subTitle>poema sinfonico per orchestra</subTitle>
+         </titleInfo>
+         <titleInfo type="uniform">
+            <title>Fontane di Roma</title>
+         </titleInfo>
+         <name type="personal">
+            <namePart>Respighi, Ottorino</namePart>
+            <namePart type="date">1879-1936</namePart>
+            <role>
+               <roleTerm authority="marcrelator" type="text">creator</roleTerm>
+            </role>
+         </name>
+         <typeOfResource>notated music</typeOfResource>
+         <originInfo>
+            <place>
+               <placeTerm type="code" authority="marccountry">it</placeTerm>
+            </place>
+            <place>
+               <placeTerm type="text">Milano</placeTerm>
+            </place>
+            <place>
+               <placeTerm type="text">New York</placeTerm>
+            </place>
+            <publisher>G. Ricordi</publisher>
+            <dateIssued>1947, c1918</dateIssued>
+            <dateIssued encoding="marc" keyDate="yes">1947</dateIssued>
+            <issuance>monographic</issuance>
+         </originInfo>
+         <language>
+            <languageTerm authority="iso639-2b" type="code">N/A</languageTerm>
+         </language>
+         <physicalDescription>
+            <form authority="marcform">print</form>
+            <extent>1 score (64 p.) ; 32 cm.</extent>
+         </physicalDescription>
+         <tableOfContents>La fontana di Valle Giulia all'alba -- La fontana del Tritone al mattino -- La fontana di Trevi al meriggio -- La fontana di Villa Medici al tramonto.</tableOfContents>
+         <note displayLabel="statement of responsibility">di Ottorino Respighi.</note>
+         <subject authority="lcsh">
+            <topic>Symphonic poems</topic>
+            <topic>Scores</topic>
+         </subject>
+         <identifier type="music plate">P.R.206 G. Ricordi</identifier>
+         <identifier type="uri">http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405</identifier>
+         <location>
+            <url usage="primary display"
+                 note="Available to authorized users of the Variations System">http://purl.dlib.indiana.edu/iudl/variations/score/BHR9405</url>
+         </location>
+         <recordInfo>
+            <recordContentSource authority="marcorg">BOS</recordContentSource>
+            <recordCreationDate encoding="marc">830420</recordCreationDate>
+            <recordIdentifier>BHR9405BM</recordIdentifier>
+         </recordInfo>
+      </mods>
+      </mets:xmlData>
+    </mets:mdWrap>
+  </mets:dmdSec>
+  <mets:fileSec>
+    <mets:fileGrp USE="thumbnail">
+      <mets:file ID="jaie2" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/MS-METS/bhr9405/bhr9405-1-1.tif"/>
+      </mets:file>
+    </mets:fileGrp>
+    <mets:fileGrp USE="masters">
+      <mets:file CHECKSUM="aa2c70843bbd652b0a8ba426b7bc9211c547f9de" CHECKSUMTYPE="SHA-1" ID="gjpt0" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/MS-METS/bhr9405/bhr9405-1-1.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="fa82535e33a8dc15b0b24e3cbd6323e7c974a94a" CHECKSUMTYPE="SHA-1" ID="i6wt6" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/MS-METS/bhr9405/bhr9405-1-2.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="1ffec33048911228b4a771ec41db7cbe394a75dd" CHECKSUMTYPE="SHA-1" ID="goszd" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/MS-METS/bhr9405/bhr9405-1-3.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="75b9361cceb1f6e55e0aefe5ad1fe9502bed7a88" CHECKSUMTYPE="SHA-1" ID="v6huf" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/MS-METS/bhr9405/bhr9405-1-4.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="8da4ab9cfbbc3667015cf5c8b8168fac6f96c95e" CHECKSUMTYPE="SHA-1" ID="x3mmf" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/MS-METS/bhr9405/bhr9405-1-5.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="b4aeccba14d3940dc1bb139e90b2835dfbb90aa7" CHECKSUMTYPE="SHA-1" ID="jups6" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/MS-METS/bhr9405/bhr9405-1-6.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="63169dc49949bc19bdcefa073b0f8d2c1362397" CHECKSUMTYPE="SHA-1" ID="vx5y2" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/MS-METS/bhr9405/bhr9405-1-7.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="33882574c2d37194804162139d6bcac9f74eab5f" CHECKSUMTYPE="SHA-1" ID="lss1c" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/MS-METS/bhr9405/bhr9405-1-8.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="14b969c4a613e5e00428eb37ba0401784f826076" CHECKSUMTYPE="SHA-1" ID="sv600" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/MS-METS/bhr9405/bhr9405-1-9.tif"/>
+      </mets:file>
+      <mets:file CHECKSUM="49fa156b036e8c83519351e46ffcd3ded6852dc8" CHECKSUMTYPE="SHA-1" ID="vu4ez" MIMETYPE="image/tiff">
+        <mets:FLocat LOCTYPE="URL" xlink:href="file:///tmp/MS-METS/bhr9405/bhr9405-1-10.tif"/>
+      </mets:file>
+    </mets:fileGrp>
+  </mets:fileSec>
+  <mets:structMap LABEL="Foliation" TYPE="Physical">
+    <mets:div DMDID="mlys4 wvyxo" ID="cy0vu" LABEL="Fontane di Roma" TYPE="RTLBoundManuscript">
+      <mets:div ID="un5sd" LABEL="[i]" ORDER="1" TYPE="Folio">
+        <mets:fptr FILEID="gjpt0"/>
+      </mets:div>
+      <mets:div ID="gj73d" LABEL="[ii]" ORDER="2" TYPE="Folio">
+        <mets:fptr FILEID="i6wt6"/>
+      </mets:div>
+      <mets:div ID="eagn7" LABEL="[iii]" ORDER="3" TYPE="Folio">
+          <mets:fptr FILEID="goszd"/>
+      </mets:div>
+      <mets:div ID="fagn7" LABEL="[iv]" ORDER="4" TYPE="Folio">
+          <mets:fptr FILEID="v6huf"/>
+      </mets:div>
+      <mets:div ID="vr579" LABEL="[v]" ORDER="5" TYPE="Folio">
+        <mets:fptr FILEID="x3mmf"/>
+      </mets:div>
+      <mets:div ID="vr578" LABEL="[vi]" ORDER="6" TYPE="Folio">
+         <mets:fptr FILEID="jups6"/>
+      </mets:div>
+      <mets:div ID="vr577" LABEL="1" ORDER="7" TYPE="Folio">
+         <mets:fptr FILEID="vx5y2"/>
+      </mets:div>
+      <mets:div ID="vr576" LABEL="2" ORDER="8" TYPE="Folio">
+         <mets:fptr FILEID="lss1c"/>
+      </mets:div>
+      <mets:div ID="vr575" LABEL="3" ORDER="9" TYPE="Folio">
+         <mets:fptr FILEID="sv600"/>
+      </mets:div>
+      <mets:div ID="vr574" LABEL="4" ORDER="10" TYPE="Folio">
+         <mets:fptr FILEID="vu4ez"/>
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+  <mets:structMap LABEL="Contents" TYPE="Logical">
+    <mets:div DMDID="mlys4 wvyxo" ID="pmm7e" LABEL="Fontane di Roma" TYPE="Work">
+      <mets:div ID="s3io1" LABEL="[Title Page and Copyright Page]" ORDER="1" TYPE="Section">
+         <mets:div ID="yue10" ORDER="1" TYPE="LogicalMember">
+           <mets:fptr FILEID="gjpt0"/>
+         </mets:div>
+         <mets:div ID="yue11" ORDER="2" TYPE="LogicalMember">
+           <mets:fptr FILEID="i6wt6"/>
+         </mets:div>
+      </mets:div>
+      <mets:div ID="bccp5" LABEL="[Notes]" ORDER="2" TYPE="Section">
+         <mets:div ID="yue12" ORDER="1" TYPE="LogicalMember">
+           <mets:fptr FILEID="goszd"/>
+         </mets:div>
+         <mets:div ID="yue13" ORDER="2" TYPE="LogicalMember">
+           <mets:fptr FILEID="v6huf"/>
+         </mets:div>
+      </mets:div>
+      <mets:div ID="bcco5" LABEL="[Orchestration]" ORDER="3" TYPE="Section">
+         <mets:div ID="yue14" ORDER="1" TYPE="LogicalMember">
+           <mets:fptr FILEID="x3mmf"/>
+         </mets:div>
+         <mets:div ID="yue15" ORDER="2" TYPE="LogicalMember">
+           <mets:fptr FILEID="jups6"/>
+         </mets:div>
+      </mets:div>
+      <mets:div ID="bc105" LABEL="Fontane de Roma : Poema Sinfonico" ORDER="4" TYPE="Section">
+        <mets:div ID="yue2l" ORDER="1" LABEL="La fontana di Valle Giulia all alba" TYPE="Section">
+           <mets:div ID="yue2l" ORDER="1" TYPE="LogicalMember">
+             <mets:fptr FILEID="vx5y2"/>
+           </mets:div>
+           <mets:div ID="yue22" ORDER="2" TYPE="LogicalMember">
+             <mets:fptr FILEID="lss1c"/>
+           </mets:div>
+           <mets:div ID="yue23" ORDER="3" TYPE="LogicalMember">
+             <mets:fptr FILEID="sv600"/>
+           </mets:div>
+           <mets:div ID="yue24" ORDER="4" TYPE="LogicalMember">
+             <mets:fptr FILEID="vu4ez"/>
+           </mets:div>
+        </mets:div>
+      </mets:div>
+    </mets:div>
+  </mets:structMap>
+</mets:mets>

--- a/spec/fixtures/variations_mets/bhr9405.yml
+++ b/spec/fixtures/variations_mets/bhr9405.yml
@@ -1,0 +1,123 @@
+---
+:identifier: ark:/88435/bv73c047c
+:replaces: pudl0032/ns73
+:source_metadata_identifier: BHR9405
+:viewing_direction: right-to-left
+:thumbnail_path: "/tmp/MS-METS/bhr9405/bhr9405-1-1.tif"
+:structure:
+  :nodes:
+  - :label: "[Title Page and Copyright Page]"
+    :nodes:
+    - :label: ''
+      :proxy: gjpt0
+    - :label: ''
+      :proxy: i6wt6
+  - :label: "[Notes]"
+    :nodes:
+    - :label: ''
+      :proxy: goszd
+    - :label: ''
+      :proxy: v6huf
+  - :label: "[Orchestration]"
+    :nodes:
+    - :label: ''
+      :proxy: x3mmf
+    - :label: ''
+      :proxy: jups6
+  - :label: 'Fontane de Roma : Poema Sinfonico'
+    :nodes:
+    - :label: La fontana di Valle Giulia all alba
+      :nodes:
+      - :label: ''
+        :proxy: vx5y2
+      - :label: ''
+        :proxy: lss1c
+      - :label: ''
+        :proxy: sv600
+      - :label: ''
+        :proxy: vu4ez
+:files:
+- :id: gjpt0
+  :checksum: aa2c70843bbd652b0a8ba426b7bc9211c547f9de
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-1.tif"
+  :title:
+  - "[i]"
+  :replaces: pudl0032/ns73/bhr9405-1-1
+  :file_opts: {}
+- :id: i6wt6
+  :checksum: fa82535e33a8dc15b0b24e3cbd6323e7c974a94a
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-2.tif"
+  :title:
+  - "[ii]"
+  :replaces: pudl0032/ns73/bhr9405-1-2
+  :file_opts: {}
+- :id: goszd
+  :checksum: 1ffec33048911228b4a771ec41db7cbe394a75dd
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-3.tif"
+  :title:
+  - "[iii]"
+  :replaces: pudl0032/ns73/bhr9405-1-3
+  :file_opts: {}
+- :id: v6huf
+  :checksum: 75b9361cceb1f6e55e0aefe5ad1fe9502bed7a88
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-4.tif"
+  :title:
+  - "[iv]"
+  :replaces: pudl0032/ns73/bhr9405-1-4
+  :file_opts: {}
+- :id: x3mmf
+  :checksum: 8da4ab9cfbbc3667015cf5c8b8168fac6f96c95e
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-5.tif"
+  :title:
+  - "[v]"
+  :replaces: pudl0032/ns73/bhr9405-1-5
+  :file_opts: {}
+- :id: jups6
+  :checksum: b4aeccba14d3940dc1bb139e90b2835dfbb90aa7
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-6.tif"
+  :title:
+  - "[vi]"
+  :replaces: pudl0032/ns73/bhr9405-1-6
+  :file_opts: {}
+- :id: vx5y2
+  :checksum: 63169dc49949bc19bdcefa073b0f8d2c1362397
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-7.tif"
+  :title:
+  - '1'
+  :replaces: pudl0032/ns73/bhr9405-1-7
+  :file_opts: {}
+- :id: lss1c
+  :checksum: 33882574c2d37194804162139d6bcac9f74eab5f
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-8.tif"
+  :title:
+  - '2'
+  :replaces: pudl0032/ns73/bhr9405-1-8
+  :file_opts: {}
+- :id: sv600
+  :checksum: 14b969c4a613e5e00428eb37ba0401784f826076
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-9.tif"
+  :title:
+  - '3'
+  :replaces: pudl0032/ns73/bhr9405-1-9
+  :file_opts: {}
+- :id: vu4ez
+  :checksum: 49fa156b036e8c83519351e46ffcd3ded6852dc8
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-10.tif"
+  :title:
+  - '4'
+  :replaces: pudl0032/ns73/bhr9405-1-10
+  :file_opts: {}
+:source:
+  :title:
+  - METS XML
+  :file: spec/fixtures/variations_mets/bhr9405.mets


### PR DESCRIPTION
### Overview

This pseudo-request is mean to facilitate discussion.  To play with, it includes copies of METS files that have been slightly fudged to:
- move the ingested .tif files into the /tmp folder -- it does not include the .tiff files themselves, and I was just symbolically linking to the page01.png from an earlier iteration of PMP, so you will need to do the same if you want to actually run the ingest.
- replace the Princeton example' lookup id with 'bhr9405' so that the IUCAT lookup will succeed

You can run the METS ingest with the following:

``` sh
rake ingest_mets spec/fixtures/pudl_mets
rake ingest_mets spec/fixtures/variations_mets
```

You can run the METS->YAML, then YAML ingest, with the following:

``` sh
rake preingest_mets spec/fixtures/pudl_mets
rake preingest_mets spec/fixtures/variations_mets

rake ingest_yaml spec/fixtures/pudl_mets
rake ingest_yaml spec/fixtures/variations_mets
```

And (in theory) this should produce the exact same end result as running single-step METS ingest.
### How file ingest works

Looking at the app/jobs/ingest_mets_job.rb and app/jobs/ingest_yaml_job.rb, you'll see this procedure followed for file ingest:
1. Load the ruby wrapper object for the ingest file
2. Create a minimal record (ScannedResource, or MultiVolumeWork)
3. Apply some basic attributes provided by the ingest file wrapper
4. Apply additional attributes through the .apply_remote_metadata call
5. Attach the ingest file
6. Ingest the image files
7. Set the logical_order (if structure was provided)

What an ingestable file needs to provide, then, is:
- Basic attributes about the resultant record
- A bibliogaphic lookup value to run .apply_remote_metadata 
- A list of image files to ingest
- A logical structure (optionally, but certainly ideally)
### Notes on certain aspects of this ingest process

_Apply some basic attributes provided by the ingest file wrapper,
Apply additional attributes through the .apply_remote_metadata call_
In a two-stage preingest+ingest process, it might make more sense run any .apply_remote_metadata call (if needed) and stash the result during preingest.  (This would also afford the opportunity to pull remote metadata from elsewhere, or pull it all from the local file if it already has everything pertinent.)

_Attach the ingest file_
For a preingest+ingest process, I'm not sure if we'd want to attach only the original file (METS), or only the ingested file (YAML), or both.  The current code does both.  The ingestable YAML adds fields to note the type and path of the original preingest source; this is the only addition made to information taken from the METS wrapper.

_Set the logical_order (if structure was provided)_
This is the trickiest thing to provide.  Viewing the METS->YAML resultant .yml files shows this structure pretty clearly; it's a nested hash, used to generate table-of-contents manifest in the page turner, with "label" providing a label for a section or page, and "proxy" providing the unique ID reference to a page.  This must match the unique :id value for a page in the list of files -- after the files are ingested, and the Fedora internal ID is available for the resultant FileSet, the structure hash is walked over to replace the "proxy" value with the finalized Fedora internal ID.  Logistically, this cannot be done until after files are ingested -- but this is the only modification or addition to preingest/ingest data that is _necessarily_ done during ingest, rather than prior.
