### PR TITLE
Concept for Variations->YAML preingest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,38 +55,6 @@ GIT
       sprockets-es6
 
 GIT
-  remote: git://github.com/projecthydra-labs/hydra-pcdm.git
-  revision: 854e13cc324e95fd329eb0a812815d2d78abf951
-  branch: master
-  specs:
-    hydra-pcdm (0.9.0)
-      active-fedora (>= 10, < 12)
-      mime-types (>= 1)
-
-GIT
-  remote: git://github.com/projecthydra-labs/hydra-works.git
-  revision: d41be82540eca9d3a76301df3dcea5b74c9d5937
-  branch: master
-  specs:
-    hydra-works (0.14.0)
-      hydra-derivatives (~> 3.0)
-      hydra-file_characterization (~> 0.3, >= 0.3.3)
-      hydra-pcdm (>= 0.8)
-      om (~> 3.1)
-
-GIT
-  remote: git://github.com/projecthydra/hydra-derivatives.git
-  revision: 8098a1b32144f692e47d99c36e48142c97254c3e
-  branch: master
-  specs:
-    hydra-derivatives (3.1.3)
-      active-fedora (>= 9.0, < 12)
-      activesupport (>= 4.0, < 6)
-      deprecation
-      mime-types (> 2.0, < 4.0)
-      mini_magick (>= 3.2, < 5)
-
-GIT
   remote: git://github.com/pulibrary/pul_metadata_services.git
   revision: c485eeff36d56c12255a95e5449727370820d53e
   branch: master
@@ -351,6 +319,12 @@ GEM
     hydra-core (10.3.0)
       hydra-access-controls (= 10.3.0)
       railties (>= 4.0.0, < 6)
+    hydra-derivatives (3.1.3)
+      active-fedora (>= 9.0, < 12)
+      activesupport (>= 4.0, < 6)
+      deprecation
+      mime-types (> 2.0, < 4.0)
+      mini_magick (>= 3.2, < 5)
     hydra-editor (3.1.0)
       active-fedora (>= 9.0.0)
       almond-rails (~> 0.0.3)
@@ -364,10 +338,18 @@ GEM
       hydra-access-controls (= 10.3.0)
       hydra-core (= 10.3.0)
       rails (>= 3.2.6)
+    hydra-pcdm (0.9.0)
+      active-fedora (>= 10, < 12)
+      mime-types (>= 1)
     hydra-role-management (0.2.2)
       blacklight
       bootstrap_form
       cancancan
+    hydra-works (0.14.0)
+      hydra-derivatives (~> 3.0)
+      hydra-file_characterization (~> 0.3, >= 0.3.3)
+      hydra-pcdm (>= 0.8)
+      om (~> 3.1)
     i18n (0.7.0)
     iso-639 (0.2.8)
     jasmine-core (2.5.1)
@@ -706,17 +688,17 @@ DEPENDENCIES
   capistrano-rails-console
   capybara
   coffee-rails (~> 4.1.0)
-  coveralls (= 0.8.3)
+  coveralls
   curation_concerns!
   devise (~> 3.0)
   devise-guests (~> 0.3)
   ezid-client
   factory_girl_rails
   fcrepo_wrapper (~> 0.6.0)
-  hydra-derivatives!
-  hydra-pcdm!
+  hydra-derivatives
+  hydra-pcdm
   hydra-role-management (~> 0.2.0)
-  hydra-works!
+  hydra-works
   iiif-presentation!
   iso-639
   jasmine-jquery-rails
@@ -749,7 +731,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   sidekiq
-  simplecov (~> 0.9)
+  simplecov
   sinatra
   solr_wrapper (~> 0.18.0)
   spring
@@ -764,4 +746,4 @@ DEPENDENCIES
   webmock (~> 1.0)
 
 BUNDLED WITH
-   1.12.3
+   1.12.5

--- a/app/jobs/preingest_variations_job.rb
+++ b/app/jobs/preingest_variations_job.rb
@@ -24,9 +24,7 @@ class PreingestVariationsJob < ActiveJob::Base
       yaml_hash[:source_metadata_identifier] = @variations.xpath('//MediaObject/Label').first.content.to_s
       yaml_hash[:viewing_direction] = 'right-to-left'
       yaml_hash[:thumbnail_path] = ''
-      #
-      # check single or multi-volume
-      #
+
       # get files list
       @files = []
       @variations.xpath('//FileInfos/FileInfo').each do |file|
@@ -35,41 +33,60 @@ class PreingestVariationsJob < ActiveJob::Base
         file_hash[:checksum] = file.xpath('Checksum').first&.content.to_s
         file_hash[:mime_type] = 'image/tiff'
         file_hash[:path] = '/tmp/MS-METS/bhr9405/' + file_hash[:id]
-        file_hash[:title] = ['TITLE MISSING'] #replaced later
+        file_hash[:title] = ['TITLE MISSING'] # replaced later
         file_hash[:replaces] = 'replaces'
         file_hash[:file_opts] = {}
         @files << file_hash
       end
-      s_root = @variations.xpath('/ScoreAccessPage/RecordSet/Container/Structure/Item').first
-      yaml_hash[:structure] = {}
-      @file_index = 0
-      yaml_hash[:structure][:nodes] = structure_to_array('foo', s_root)
-      yaml_hash[:files] = @files
       yaml_hash[:thumbnail_path] = @files.first[:path]
+
+      # assign structure hash and files array
+      @file_index = 0
+      items = @variations.xpath('/ScoreAccessPage/RecordSet/Container/Structure/Item')
+      if items.size < 2
+        s_root = @variations.xpath('/ScoreAccessPage/RecordSet/Container/Structure/Item').first
+        yaml_hash[:structure] = {}
+        yaml_hash[:structure][:nodes] = structure_to_array(s_root)
+        yaml_hash[:files] = @files
+      else
+        yaml_hash[:volumes] = []
+        @file_start = 0
+        items.each do |item|
+          volume = {}
+          volume[:id] = 'ID GOES HERE'
+          volume[:title] = [item['label']]
+          volume[:nodes] = structure_to_array(item)
+          volume[:files] = @files[@file_start, @file_index - @file_start]
+          @file_start = @file_index
+          yaml_hash[:volumes] << volume
+        end
+      end
 
       yaml_hash[:source] = {}
       yaml_hash[:source][:title] = ['Variations XML']
       yaml_hash[:source][:file] = @variations_file
+
       yaml_file = @variations_file.sub(/\.xml$/, '.yml')
       File.write(yaml_file, yaml_hash.to_yaml)
       logger.info "Created YAML file #{File.basename(yaml_file)}"
     end
 
-    def structure_to_array(basename, xml_node)
+    # builds structure hash AND update file list with titles
+    def structure_to_array(xml_node)
       array = []
       xml_node.xpath('child::*').each do |child|
         c = {}
         if child.name == 'Div'
           c[:label] = child['label']
-          c[:nodes] = structure_to_array(basename, child)
-          array << c
+          c[:nodes] = structure_to_array(child)
         elsif child.name == 'Chunk'
           c[:label] = child['label']
-          @files[@file_index][:title] = [child['label']]
           c[:proxy] = @files[@file_index][:id]
+
+          @files[@file_index][:title] = [child['label']]
           @file_index += 1
-          array << c
         end
+        array << c
       end
       array
     end

--- a/app/jobs/preingest_variations_job.rb
+++ b/app/jobs/preingest_variations_job.rb
@@ -1,0 +1,77 @@
+class PreingestVariationsJob < ActiveJob::Base
+  queue_as :preingest
+
+  # @param [String] variations_file Filename of a Variations file to ingest
+  # @param [String] user User to ingest as
+  # @param [Array<String>] collections Collection IDs the resources should be members of
+  def perform(variations_file, user, collections = [])
+    logger.info "Preingesting Variations score #{variations_file}"
+    @variations_file = variations_file
+    @variations = Nokogiri::XML(File.read(variations_file))
+    @user = user
+    @collections = collections.map { |col_id| Collection.find(col_id) }
+
+    preingest
+  end
+
+  private
+
+    def preingest
+      yaml_hash = {}
+      # get simple attributes
+      yaml_hash[:identifier] = 'identifier'
+      yaml_hash[:replaces] = 'replaces'
+      yaml_hash[:source_metadata_identifier] = @variations.xpath('//MediaObject/Label').first.content.to_s
+      yaml_hash[:viewing_direction] = 'right-to-left'
+      yaml_hash[:thumbnail_path] = ''
+      #
+      # check single or multi-volume
+      #
+      # get files list
+      @files = []
+      @variations.xpath('//FileInfos/FileInfo').each do |file|
+        file_hash = {}
+        file_hash[:id] = file.xpath('FileName').first&.content.to_s
+        file_hash[:checksum] = file.xpath('Checksum').first&.content.to_s
+        file_hash[:mime_type] = 'image/tiff'
+        file_hash[:path] = '/tmp/MS-METS/bhr9405/' + file_hash[:id]
+        file_hash[:title] = ['TITLE MISSING'] #replaced later
+        file_hash[:replaces] = 'replaces'
+        file_hash[:file_opts] = {}
+        @files << file_hash
+      end
+      s_root = @variations.xpath('/ScoreAccessPage/RecordSet/Container/Structure/Item').first
+      yaml_hash[:structure] = {}
+      @file_index = 0
+      yaml_hash[:structure][:nodes] = structure_to_array('foo', s_root)
+      yaml_hash[:files] = @files
+      yaml_hash[:thumbnail_path] = @files.first[:path]
+
+      yaml_hash[:source] = {}
+      yaml_hash[:source][:title] = ['Variations XML']
+      yaml_hash[:source][:file] = @variations_file
+      yaml_file = @variations_file.sub(/\.xml$/, '.yml')
+      File.write(yaml_file, yaml_hash.to_yaml)
+      logger.info "Created YAML file #{File.basename(yaml_file)}"
+    end
+
+    def structure_to_array(basename, xml_node)
+      array = []
+      xml_node.xpath('child::*').each do |child|
+        c = {}
+        if child.name == 'Div'
+          c[:label] = child['label']
+          c[:nodes] = structure_to_array(basename, child)
+          array << c
+        elsif child.name == 'Chunk'
+          c[:label] = child['label']
+          @files[@file_index][:title] = [child['label']]
+          c[:proxy] = @files[@file_index][:id]
+          @file_index += 1
+          array << c
+        end
+      end
+      array
+    end
+
+end

--- a/lib/tasks/preingest_variations.rake
+++ b/lib/tasks/preingest_variations.rake
@@ -1,0 +1,21 @@
+desc "Preingest one or more Variations files"
+task preingest_variations: :environment do
+  user = User.find_by_user_key( ENV['USER'] ) if ENV['USER']
+  user = User.all.select{ |u| u.admin? }.first unless user
+
+  collections = (ENV['COLLECTIONS'] || "").split(" ")
+
+  logger = Logger.new(STDOUT)
+  PreingestVariationsJob.logger = logger
+  logger.info "preingesting xml files from: #{ARGV[1]}"
+  logger.info "preingesting as: #{user.user_key} (override with USER=foo)"
+  abort "usage: rake ingest_variations /path/to/xml/files" unless ARGV[1] && Dir.exist?(ARGV[1])
+  Dir["#{ARGV[1]}/**/*.xml"].each do |file|
+    begin
+      PreingestVariationsJob.perform_now(file, user, collections)
+    rescue => e
+      puts "Error: #{e.message}"
+      puts e.backtrace
+    end
+  end
+end

--- a/spec/fixtures/variations_xml/abe9721.xml
+++ b/spec/fixtures/variations_xml/abe9721.xml
@@ -1,0 +1,4623 @@
+<ScoreAccessPage>
+  <HtmlPageStatus>None</HtmlPageStatus>
+  <Bibinfo>
+    <Author>Chopin, Frédéric, 1810-1849</Author>
+  </Bibinfo>
+
+<RecordSet version="5.1">
+   <MediaObject>
+      <Label>ABE9721</Label>
+      <FileFormat>image/x.djvu</FileFormat>
+      <ChannelCount>0</ChannelCount>
+      <SampleSize>0</SampleSize>
+      <SampleRate>0</SampleRate>
+      <Environment>Fujitsu Model fi4750C</Environment>
+      <DigitizationDate>2009-01-13</DigitizationDate>
+      <DigitizedBy>epeebles@IU.EDU</DigitizedBy>
+      <AccessCount>0</AccessCount>
+      <FileInfos>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-1.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-2.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-3.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-4.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-5.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-6.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-7.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-8.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-9.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-10.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-11.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-12.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-13.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-14.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-15.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-16.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-17.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-18.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-19.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-20.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-21.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-22.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-23.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-24.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-25.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-26.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-27.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-28.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-29.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-30.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-31.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-32.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-33.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-34.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-35.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-36.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-37.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-38.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-39.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-40.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-41.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-42.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-43.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-44.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-45.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-46.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-47.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-48.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-49.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-50.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-51.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-52.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-53.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-54.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-55.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-56.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-57.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-58.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-59.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-60.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-61.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-62.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-63.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-64.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-65.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-66.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-67.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-68.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-69.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-70.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-71.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-72.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-73.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-74.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-75.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-76.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-77.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-78.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-79.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-80.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-81.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-82.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-83.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-84.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-85.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-86.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-87.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-88.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-89.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-90.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-91.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-92.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-93.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-94.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-95.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-96.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-97.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-98.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-99.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-100.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-101.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-102.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-103.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-104.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-105.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-106.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-107.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-108.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-109.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-110.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-111.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-112.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-113.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-114.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-115.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-116.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-117.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-118.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-119.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-120.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-121.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-122.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-123.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-124.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-125.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-126.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-127.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-128.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-129.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-1-130.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-1.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-2.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-3.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-4.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-5.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-6.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-7.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-8.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-9.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-10.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-11.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-12.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-13.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-14.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-15.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-16.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-17.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-18.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-19.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-20.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-21.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-22.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-23.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-24.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-25.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-26.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-27.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-28.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-29.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-30.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-31.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-32.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-33.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-34.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-35.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-36.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-37.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-38.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-39.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-40.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-41.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-42.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-43.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-44.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-45.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-46.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-47.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-48.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-49.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-50.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-51.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-52.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-53.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-54.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-55.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-56.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-57.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-58.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-59.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-60.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-61.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-62.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-63.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-64.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-65.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-66.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-67.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-68.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-69.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-70.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-71.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-72.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-73.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-74.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-75.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-76.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-77.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-78.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-79.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-80.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-81.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-82.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-83.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-84.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-85.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-86.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-87.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-88.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-89.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-90.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-91.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-92.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-93.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-94.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-95.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-96.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-97.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-98.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-99.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-100.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-101.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-102.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-103.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-104.djvu</FileName>
+            <Checksum>KRofxQUapZF9FfCRBE2Szw==</Checksum>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-105.djvu</FileName>
+            <Checksum>SPReAxcqLYaQnAhXBiootQ==</Checksum>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-106.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-107.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-108.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-109.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-110.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-111.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-112.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-113.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-114.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-115.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-116.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-117.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-118.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-119.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-120.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-121.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-2-122.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-1.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-2.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-3.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-4.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-5.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-6.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-7.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-8.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-9.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-10.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-11.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-12.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-13.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-14.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-15.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-16.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-17.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-18.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-19.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-20.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-21.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-22.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-23.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-24.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-25.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-26.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-27.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-28.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-29.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-30.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-31.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-32.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-3-33.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-1.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-2.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-3.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-4.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-5.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-6.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-7.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-8.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-9.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-10.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-11.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-12.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-13.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-14.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-15.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-16.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-17.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-18.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-19.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-20.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-21.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-22.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-23.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-24.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-25.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-26.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-27.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-28.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-29.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-30.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-31.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-32.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-33.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-34.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-35.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-36.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-37.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-38.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-39.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-40.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-41.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-42.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-43.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-44.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-45.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-46.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-47.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-48.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-49.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-50.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-51.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-52.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-53.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-54.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-55.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-56.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-57.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-58.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-59.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-60.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-61.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-62.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-63.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-64.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-65.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-66.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-67.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-68.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-69.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-70.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-71.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-72.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-73.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-74.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-75.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-76.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-77.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-78.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-79.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-80.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-81.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-82.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-83.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-84.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-85.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-86.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-87.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-88.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-89.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-90.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-91.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-92.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-93.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-94.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-95.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-96.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-97.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-98.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-99.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-100.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-101.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-102.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-103.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-104.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-105.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-106.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-107.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-108.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-109.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-110.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-111.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-112.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-113.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-114.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-115.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-116.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-117.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-118.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-119.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-120.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-121.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-122.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-123.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-124.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-125.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-126.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-127.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-128.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-129.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-130.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-131.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-132.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-133.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-134.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-135.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-136.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-137.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-138.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-139.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-140.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-141.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-142.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-143.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-144.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-145.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-146.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-147.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>abe9721-5-148.djvu</FileName>
+            <Creation>2009-01-14 13:43:48.0</Creation>
+            <Update>2009-01-14 13:43:48.0</Update>
+         </FileInfo>
+      </FileInfos>
+      <Id>IU/MediaObject/446921</Id>
+      <CreationInfo>
+         <User>epeebles@IU.EDU</User>
+         <Timestamp>2009-01-13 10:02:55.0</Timestamp>
+      </CreationInfo>
+      <UpdateInfo>
+         <User>ppagels@IU.EDU</User>
+         <Timestamp>2009-03-30 13:15:35.0</Timestamp>
+      </UpdateInfo>
+      <Status>Complete</Status>
+   </MediaObject>
+   <Container>
+      <DisplayTitle offset="4">The facsimil[e] edition of the autograph of Fryderyk Chopin's works : from the Collection Fryderyk Chopin Society in Warsaw</DisplayTitle>
+      <Publisher>Fryderyk Chopin Society</Publisher>
+      <DocumentInfos>
+         <DocumentInfo>
+            <Type>Score</Type>
+            <Format>Full Score</Format>
+            <Description>   v. of music : facsims. ; 36 x 44 cm</Description>
+         </DocumentInfo>
+      </DocumentInfos>
+      <PublicationDate>1990</PublicationDate>
+      <CopyrightDate>1990</CopyrightDate>
+      <PublicationPlace>Warsaw : Tokyo</PublicationPlace>
+      <BibliographicNotes>
+         <BibliographicNote>
+            <Type>Descriptive</Type>
+            <Text>Reproductions of holographs and 1st editions</Text>
+         </BibliographicNote>
+         <BibliographicNote>
+            <Type>Descriptive</Type>
+            <Text>Title from container</Text>
+         </BibliographicNote>
+         <BibliographicNote>
+            <Type>Descriptive</Type>
+            <Text>Vol. 1-2 in portfolios; consisting of sheets in wrappers</Text>
+         </BibliographicNote>
+      </BibliographicNotes>
+      <Structure label="The facsimil[e] edition of the autograph of Fryderyk Chopin's works : from the Collection Fryderyk Chopin Society in Warsaw">
+         <Item label="The facsimil[e] edition of the autograph of Fryderyk Chopin's works : from the Collection Fryderyk Chopin Society in Warsaw, volume 1">
+            <Div label="[Contents]">
+               <Chunk label="[1:1]">
+                  <ContentInterval begin="0" end="1" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Mazurka in F-minor, op. 7-3]">
+               <Chunk label="[1:2]">
+                  <ContentInterval begin="1" end="2" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:3]">
+                  <ContentInterval begin="2" end="3" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:4]">
+                  <ContentInterval begin="3" end="4" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:5]">
+                  <ContentInterval begin="4" end="5" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Trio in G-minor, for pianoforte, violin, cello, op. 8]">
+               <Chunk label="[1:6]">
+                  <ContentInterval begin="5" end="6" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:7]">
+                  <ContentInterval begin="6" end="7" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:8]">
+                  <ContentInterval begin="7" end="8" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:9]">
+                  <ContentInterval begin="8" end="9" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:10]">
+                  <ContentInterval begin="9" end="10" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:11]">
+                  <ContentInterval begin="10" end="11" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:12]">
+                  <ContentInterval begin="11" end="12" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:13]">
+                  <ContentInterval begin="12" end="13" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:14]">
+                  <ContentInterval begin="13" end="14" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:15]">
+                  <ContentInterval begin="14" end="15" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:16]">
+                  <ContentInterval begin="15" end="16" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:17]">
+                  <ContentInterval begin="16" end="17" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:18]">
+                  <ContentInterval begin="17" end="18" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:19]">
+                  <ContentInterval begin="18" end="19" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:20]">
+                  <ContentInterval begin="19" end="20" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:21]">
+                  <ContentInterval begin="20" end="21" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:22]">
+                  <ContentInterval begin="21" end="22" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:23]">
+                  <ContentInterval begin="22" end="23" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:24]">
+                  <ContentInterval begin="23" end="24" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:25]">
+                  <ContentInterval begin="24" end="25" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:26]">
+                  <ContentInterval begin="25" end="26" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:27]">
+                  <ContentInterval begin="26" end="27" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:28]">
+                  <ContentInterval begin="27" end="28" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:29]">
+                  <ContentInterval begin="28" end="29" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:30]">
+                  <ContentInterval begin="29" end="30" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:31]">
+                  <ContentInterval begin="30" end="31" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:32]">
+                  <ContentInterval begin="31" end="32" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:33]">
+                  <ContentInterval begin="32" end="33" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:34]">
+                  <ContentInterval begin="33" end="34" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:35]">
+                  <ContentInterval begin="34" end="35" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:36]">
+                  <ContentInterval begin="35" end="36" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:37]">
+                  <ContentInterval begin="36" end="37" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Study in E-major, op. 10-3]">
+               <Chunk label="[1:38]">
+                  <ContentInterval begin="37" end="38" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:39]">
+                  <ContentInterval begin="38" end="39" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:40]">
+                  <ContentInterval begin="39" end="40" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:41]">
+                  <ContentInterval begin="40" end="41" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Study in G-flat-major, op. 10-5]">
+               <Chunk label="[1:42]">
+                  <ContentInterval begin="41" end="42" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:43]">
+                  <ContentInterval begin="42" end="43" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:44]">
+                  <ContentInterval begin="43" end="44" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:45]">
+                  <ContentInterval begin="44" end="45" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Study in E-flat-minor, op. 10-6]">
+               <Chunk label="[1:46]">
+                  <ContentInterval begin="45" end="46" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:47]">
+                  <ContentInterval begin="46" end="47" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:48]">
+                  <ContentInterval begin="47" end="48" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:49]">
+                  <ContentInterval begin="48" end="49" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Study in F-major, op. 10-8]">
+               <Chunk label="[1:50]">
+                  <ContentInterval begin="49" end="50" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:51]">
+                  <ContentInterval begin="50" end="51" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:52]">
+                  <ContentInterval begin="51" end="52" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:53]">
+                  <ContentInterval begin="52" end="53" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:54]">
+                  <ContentInterval begin="53" end="54" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:55]">
+                  <ContentInterval begin="54" end="55" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Study in F-minor, op. 10-9]">
+               <Chunk label="[1:56]">
+                  <ContentInterval begin="55" end="56" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:57]">
+                  <ContentInterval begin="56" end="57" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:58]">
+                  <ContentInterval begin="57" end="58" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Study in A-flat-major, op. 10-10]">
+               <Chunk label="[1:59]">
+                  <ContentInterval begin="58" end="59" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:60]">
+                  <ContentInterval begin="59" end="60" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:61]">
+                  <ContentInterval begin="60" end="61" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:62]">
+                  <ContentInterval begin="61" end="62" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:63]">
+                  <ContentInterval begin="62" end="63" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Studies, 1st ed.]">
+               <Div label="[Front cover]">
+                  <Chunk label="[1:64]">
+                     <ContentInterval begin="63" end="64" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:65]">
+                     <ContentInterval begin="64" end="65" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="[Study in C-major, op. 10-1, 1st ed.]">
+                  <Chunk label="[1:66]">
+                     <ContentInterval begin="65" end="66" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:67]">
+                     <ContentInterval begin="66" end="67" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:68]">
+                     <ContentInterval begin="67" end="68" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:69]">
+                     <ContentInterval begin="68" end="69" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:70]">
+                     <ContentInterval begin="69" end="70" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="[Study in A-minor, op. 10-2, 1st ed.]">
+                  <Chunk label="[1:71]">
+                     <ContentInterval begin="70" end="71" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:72]">
+                     <ContentInterval begin="71" end="72" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:73]">
+                     <ContentInterval begin="72" end="73" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:74]">
+                     <ContentInterval begin="73" end="74" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:75]">
+                     <ContentInterval begin="74" end="75" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="[Study in C-sharp-minor, op. 10-4, 1st ed.]">
+                  <Chunk label="[1:76]">
+                     <ContentInterval begin="75" end="76" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:77]">
+                     <ContentInterval begin="76" end="77" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:78]">
+                     <ContentInterval begin="77" end="78" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:79]">
+                     <ContentInterval begin="78" end="79" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:80]">
+                     <ContentInterval begin="79" end="80" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="[Study in C-major, op. 10-7, 1st ed.]">
+                  <Chunk label="[1:81]">
+                     <ContentInterval begin="80" end="81" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:82]">
+                     <ContentInterval begin="81" end="82" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:83]">
+                     <ContentInterval begin="82" end="83" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:84]">
+                     <ContentInterval begin="83" end="84" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Study in E-flat-major, op 10-11, 1st ed.]">
+                  <Chunk label="[1:85]">
+                     <ContentInterval begin="84" end="85" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:86]">
+                     <ContentInterval begin="85" end="86" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:87]">
+                     <ContentInterval begin="86" end="87" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="[Study in C-minor, op. 10-12, 1st ed.]">
+                  <Chunk label="[1:88]">
+                     <ContentInterval begin="87" end="88" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:89]">
+                     <ContentInterval begin="88" end="89" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:90]">
+                     <ContentInterval begin="89" end="90" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:91]">
+                     <ContentInterval begin="90" end="91" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:92]">
+                     <ContentInterval begin="91" end="92" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[1:93]">
+                     <ContentInterval begin="92" end="93" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+            </Div>
+            <Div label="[Impromptu in A-flat major, op. 29]">
+               <Chunk label="[1:94]">
+                  <ContentInterval begin="93" end="94" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:95]">
+                  <ContentInterval begin="94" end="95" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:96]">
+                  <ContentInterval begin="95" end="96" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:97]">
+                  <ContentInterval begin="96" end="97" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:98]">
+                  <ContentInterval begin="97" end="98" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:99]">
+                  <ContentInterval begin="98" end="99" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:100]">
+                  <ContentInterval begin="99" end="100" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:101]">
+                  <ContentInterval begin="100" end="101" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:102]">
+                  <ContentInterval begin="101" end="102" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:103]">
+                  <ContentInterval begin="102" end="103" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:104]">
+                  <ContentInterval begin="103" end="104" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:105]">
+                  <ContentInterval begin="104" end="105" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Barcarolle in F-sharp-major, op. 60]">
+               <Chunk label="[1:106]">
+                  <ContentInterval begin="105" end="106" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:107]">
+                  <ContentInterval begin="106" end="107" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:108]">
+                  <ContentInterval begin="107" end="108" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:109]">
+                  <ContentInterval begin="108" end="109" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:110]">
+                  <ContentInterval begin="109" end="110" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:111]">
+                  <ContentInterval begin="110" end="111" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:112]">
+                  <ContentInterval begin="111" end="112" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:113]">
+                  <ContentInterval begin="112" end="113" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Polonaise in F-mainor, op. 71-3]">
+               <Chunk label="[1:114]">
+                  <ContentInterval begin="113" end="114" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:115]">
+                  <ContentInterval begin="114" end="115" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:116]">
+                  <ContentInterval begin="115" end="116" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:117]">
+                  <ContentInterval begin="116" end="117" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:118]">
+                  <ContentInterval begin="117" end="118" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:119]">
+                  <ContentInterval begin="118" end="119" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Polonaise-Fantasie in A-flat-major, op. 61]">
+               <Chunk label="[1:120]">
+                  <ContentInterval begin="119" end="120" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:121]">
+                  <ContentInterval begin="120" end="121" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:122]">
+                  <ContentInterval begin="121" end="122" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:123]">
+                  <ContentInterval begin="122" end="123" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:124]">
+                  <ContentInterval begin="123" end="124" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:125]">
+                  <ContentInterval begin="124" end="125" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:126]">
+                  <ContentInterval begin="125" end="126" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:127]">
+                  <ContentInterval begin="126" end="127" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Song for voice and pianoforte, in A-flat-major, op. 74-10 &#34;Wojak&#34; (The Warrior)]">
+               <Chunk label="[1:128]">
+                  <ContentInterval begin="127" end="128" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[1:129]">
+                  <ContentInterval begin="128" end="129" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Colophon]">
+               <Chunk label="[1:130]">
+                  <ContentInterval begin="129" end="130" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+         </Item>
+         <Item label="The facsimil[e] edition of the autograph of Fryderyk Chopin's works : from the Collection Fryderyk Chopin Society in Warsaw, volume 2">
+            <Div label="[Contents]">
+               <Chunk label="[2:1]">
+                  <ContentInterval begin="130" end="131" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Berceuse in D-flat-major, op. 57]">
+               <Chunk label="[2:2]">
+                  <ContentInterval begin="131" end="132" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:3]">
+                  <ContentInterval begin="132" end="133" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:4]">
+                  <ContentInterval begin="133" end="134" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:5]">
+                  <ContentInterval begin="134" end="135" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Sonata no. 3 in B-minor, op. 58]">
+               <Chunk label="[2:6]">
+                  <ContentInterval begin="135" end="136" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:7]">
+                  <ContentInterval begin="136" end="137" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Barcarolle in F-sharp-major, op. 60]">
+               <Chunk label="[2:8]">
+                  <ContentInterval begin="137" end="138" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:9]">
+                  <ContentInterval begin="138" end="139" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Polonaise-Fantasie in A-flat-major, op. 61]">
+               <Chunk label="[2:10]">
+                  <ContentInterval begin="139" end="140" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:11]">
+                  <ContentInterval begin="140" end="141" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Sonata in G-minor, for pianoforte and cello, op. 65]">
+               <Chunk label="[2:12]">
+                  <ContentInterval begin="141" end="142" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:13]">
+                  <ContentInterval begin="142" end="143" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:14]">
+                  <ContentInterval begin="143" end="144" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:15]">
+                  <ContentInterval begin="144" end="145" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:16]">
+                  <ContentInterval begin="145" end="146" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:17]">
+                  <ContentInterval begin="146" end="147" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:18]">
+                  <ContentInterval begin="147" end="148" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:19]">
+                  <ContentInterval begin="148" end="149" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:20]">
+                  <ContentInterval begin="149" end="150" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:21]">
+                  <ContentInterval begin="150" end="151" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:22]">
+                  <ContentInterval begin="151" end="152" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:23]">
+                  <ContentInterval begin="152" end="153" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:24]">
+                  <ContentInterval begin="153" end="154" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:25]">
+                  <ContentInterval begin="154" end="155" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:26]">
+                  <ContentInterval begin="155" end="156" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:27]">
+                  <ContentInterval begin="156" end="157" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:28]">
+                  <ContentInterval begin="157" end="158" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:29]">
+                  <ContentInterval begin="158" end="159" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:30]">
+                  <ContentInterval begin="159" end="160" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:31]">
+                  <ContentInterval begin="160" end="161" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:32]">
+                  <ContentInterval begin="161" end="162" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:33]">
+                  <ContentInterval begin="162" end="163" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:34]">
+                  <ContentInterval begin="163" end="164" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:35]">
+                  <ContentInterval begin="164" end="165" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:36]">
+                  <ContentInterval begin="165" end="166" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:37]">
+                  <ContentInterval begin="166" end="167" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:38]">
+                  <ContentInterval begin="167" end="168" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:39]">
+                  <ContentInterval begin="168" end="169" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:40]">
+                  <ContentInterval begin="169" end="170" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:41]">
+                  <ContentInterval begin="170" end="171" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:42]">
+                  <ContentInterval begin="171" end="172" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:43]">
+                  <ContentInterval begin="172" end="173" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:44]">
+                  <ContentInterval begin="173" end="174" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:45]">
+                  <ContentInterval begin="174" end="175" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:46]">
+                  <ContentInterval begin="175" end="176" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:47]">
+                  <ContentInterval begin="176" end="177" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:48]">
+                  <ContentInterval begin="177" end="178" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:49]">
+                  <ContentInterval begin="178" end="179" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:50]">
+                  <ContentInterval begin="179" end="180" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:51]">
+                  <ContentInterval begin="180" end="181" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:52]">
+                  <ContentInterval begin="181" end="182" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:53]">
+                  <ContentInterval begin="182" end="183" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:54]">
+                  <ContentInterval begin="183" end="184" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:55]">
+                  <ContentInterval begin="184" end="185" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:56]">
+                  <ContentInterval begin="185" end="186" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:57]">
+                  <ContentInterval begin="186" end="187" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:58]">
+                  <ContentInterval begin="187" end="188" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:59]">
+                  <ContentInterval begin="188" end="189" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:60]">
+                  <ContentInterval begin="189" end="190" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:61]">
+                  <ContentInterval begin="190" end="191" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:62]">
+                  <ContentInterval begin="191" end="192" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:63]">
+                  <ContentInterval begin="192" end="193" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:64]">
+                  <ContentInterval begin="193" end="194" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:65]">
+                  <ContentInterval begin="194" end="195" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:66]">
+                  <ContentInterval begin="195" end="196" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:67]">
+                  <ContentInterval begin="196" end="197" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:68]">
+                  <ContentInterval begin="197" end="198" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:69]">
+                  <ContentInterval begin="198" end="199" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:70]">
+                  <ContentInterval begin="199" end="200" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:71]">
+                  <ContentInterval begin="200" end="201" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:72]">
+                  <ContentInterval begin="201" end="202" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:73]">
+                  <ContentInterval begin="202" end="203" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:74]">
+                  <ContentInterval begin="203" end="204" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:75]">
+                  <ContentInterval begin="204" end="205" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:76]">
+                  <ContentInterval begin="205" end="206" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:77]">
+                  <ContentInterval begin="206" end="207" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:78]">
+                  <ContentInterval begin="207" end="208" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:79]">
+                  <ContentInterval begin="208" end="209" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Mazurka in F-minor, op. 68-4]">
+               <Chunk label="[2:80]">
+                  <ContentInterval begin="209" end="210" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:81]">
+                  <ContentInterval begin="210" end="211" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Song for voice and pianoforte, in A-minor, op. 74-6. &#34;Precz z moich oczu&#34; (Out of my sight)">
+               <Chunk label="[2:82]">
+                  <ContentInterval begin="211" end="212" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:83]">
+                  <ContentInterval begin="212" end="213" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Song for voice and pianoforte, in E-flat-major, op. 74-14. &#34;Pierscien&#34; (The ring)">
+               <Chunk label="[2:84]">
+                  <ContentInterval begin="213" end="214" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:85]">
+                  <ContentInterval begin="214" end="215" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Song in F-major, &#34;Dawniej polak--&#34;]">
+               <Chunk label="[2:86]">
+                  <ContentInterval begin="215" end="216" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:87]">
+                  <ContentInterval begin="216" end="217" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Refrain of &#34;Dabrowski's Mazurka&#34;]">
+               <Chunk label="[2:88]">
+                  <ContentInterval begin="217" end="218" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:89]">
+                  <ContentInterval begin="218" end="219" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Nocturne in C-minor]">
+               <Chunk label="[2:90]">
+                  <ContentInterval begin="219" end="220" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:91]">
+                  <ContentInterval begin="220" end="221" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Sonata no. 2 in B-flat-minor, op. 35]">
+               <Chunk label="[2:92]">
+                  <ContentInterval begin="221" end="222" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:93]">
+                  <ContentInterval begin="222" end="223" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Impromptu in F-sharp-major, op. 36]">
+               <Chunk label="[2:94]">
+                  <ContentInterval begin="223" end="224" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:95]">
+                  <ContentInterval begin="224" end="225" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Mazurka in G-major, op. 50-1]">
+               <Chunk label="[2:96]">
+                  <ContentInterval begin="225" end="226" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:97]">
+                  <ContentInterval begin="226" end="227" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Sonata no. 2 in B-flat-minor, op. 35, 1st ed.]">
+               <Chunk label="[2:98]">
+                  <ContentInterval begin="227" end="228" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:99]">
+                  <ContentInterval begin="228" end="229" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:100]">
+                  <ContentInterval begin="229" end="230" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:101]">
+                  <ContentInterval begin="230" end="231" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:102]">
+                  <ContentInterval begin="231" end="232" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:103]">
+                  <ContentInterval begin="232" end="233" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:104]">
+                  <ContentInterval begin="233" end="234" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:105]">
+                  <ContentInterval begin="234" end="235" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:106]">
+                  <ContentInterval begin="235" end="236" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:107]">
+                  <ContentInterval begin="236" end="237" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:108]">
+                  <ContentInterval begin="237" end="238" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:109]">
+                  <ContentInterval begin="238" end="239" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:110]">
+                  <ContentInterval begin="239" end="240" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:111]">
+                  <ContentInterval begin="240" end="241" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:112]">
+                  <ContentInterval begin="241" end="242" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:113]">
+                  <ContentInterval begin="242" end="243" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:114]">
+                  <ContentInterval begin="243" end="244" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:115]">
+                  <ContentInterval begin="244" end="245" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:116]">
+                  <ContentInterval begin="245" end="246" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:117]">
+                  <ContentInterval begin="246" end="247" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:118]">
+                  <ContentInterval begin="247" end="248" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:119]">
+                  <ContentInterval begin="248" end="249" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:120]">
+                  <ContentInterval begin="249" end="250" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[2:121]">
+                  <ContentInterval begin="250" end="251" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Colophon]">
+               <Chunk label="[2:122]">
+                  <ContentInterval begin="251" end="252" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+         </Item>
+         <Item label="The facsimil[e] edition of the autograph of Fryderyk Chopin's works : from the Collection Fryderyk Chopin Society in Warsaw, volume 3">
+            <Div label="[Cover Page]">
+               <Chunk label="[3:1]">
+                  <ContentInterval begin="252" end="253" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Photograph]">
+               <Chunk label="[3:2]">
+                  <ContentInterval begin="253" end="254" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:3]">
+                  <ContentInterval begin="254" end="255" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Description of photographs]">
+               <Chunk label="[3:4]">
+                  <ContentInterval begin="255" end="256" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Autograph]">
+               <Chunk label="[3:5]">
+                  <ContentInterval begin="256" end="257" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Series Title]">
+               <Chunk label="[3:6]">
+                  <ContentInterval begin="257" end="258" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:7]">
+                  <ContentInterval begin="258" end="259" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Title Page]">
+               <Chunk label="[3:8]">
+                  <ContentInterval begin="259" end="260" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:9]">
+                  <ContentInterval begin="260" end="261" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Acknowledgements]">
+               <Chunk label="[3:10]">
+                  <ContentInterval begin="261" end="262" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Portrait]">
+               <Chunk label="[3:11]">
+                  <ContentInterval begin="262" end="263" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:12]">
+                  <ContentInterval begin="263" end="264" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Quote]">
+               <Chunk label="[3:13]">
+                  <ContentInterval begin="264" end="265" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:14]">
+                  <ContentInterval begin="265" end="266" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Notes]">
+               <Chunk label="[3:15]">
+                  <ContentInterval begin="266" end="267" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:16]">
+                  <ContentInterval begin="267" end="268" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:17]">
+                  <ContentInterval begin="268" end="269" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:18]">
+                  <ContentInterval begin="269" end="270" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:19]">
+                  <ContentInterval begin="270" end="271" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:20]">
+                  <ContentInterval begin="271" end="272" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:21]">
+                  <ContentInterval begin="272" end="273" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:22]">
+                  <ContentInterval begin="273" end="274" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:23]">
+                  <ContentInterval begin="274" end="275" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:24]">
+                  <ContentInterval begin="275" end="276" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Polonaise in G minor, 1817, 1st ed.]">
+               <Chunk label="[3:25]">
+                  <ContentInterval begin="276" end="277" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:26]">
+                  <ContentInterval begin="277" end="278" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:27]">
+                  <ContentInterval begin="278" end="279" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:28]">
+                  <ContentInterval begin="279" end="280" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:29]">
+                  <ContentInterval begin="280" end="281" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Colophon]">
+               <Chunk label="[3:30]">
+                  <ContentInterval begin="281" end="282" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Photograph]">
+               <Chunk label="[3:31]">
+                  <ContentInterval begin="282" end="283" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[3:32]">
+                  <ContentInterval begin="283" end="284" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Back Cover]">
+               <Chunk label="[3:33]">
+                  <ContentInterval begin="284" end="285" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+         </Item>
+         <Item label="A commentary on the facsimil[e] edition of the autograph of Fryderyk Chopin's works : from the Collection Fryderyk Chopin Society in Warsaw, volume 5">
+            <Div label="[Title Page]">
+               <Chunk label="[5:1]">
+                  <ContentInterval begin="285" end="286" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Foreword]">
+               <Chunk label="[5:2]">
+                  <ContentInterval begin="286" end="287" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[5:3]">
+                  <ContentInterval begin="287" end="288" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[5:4]">
+                  <ContentInterval begin="288" end="289" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[5:5]">
+                  <ContentInterval begin="289" end="290" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[5:6]">
+                  <ContentInterval begin="290" end="291" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[5:7]">
+                  <ContentInterval begin="291" end="292" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Contents]">
+               <Chunk label="[5:8]">
+                  <ContentInterval begin="292" end="293" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[5:9]">
+                  <ContentInterval begin="293" end="294" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Acknowledgements and photographs]">
+               <Chunk label="[5:10]">
+                  <ContentInterval begin="294" end="295" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="[5:11]">
+                  <ContentInterval begin="295" end="296" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Quotes]">
+               <Chunk label="[5:12]">
+                  <ContentInterval begin="296" end="297" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="1. Complete compositions">
+               <Div label="[Half Title]">
+                  <Chunk label="[5:13]">
+                     <ContentInterval begin="297" end="298" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Mazurka in F-minor, op. 7-3">
+                  <Chunk label="5:14">
+                     <ContentInterval begin="298" end="299" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:15">
+                     <ContentInterval begin="299" end="300" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:16">
+                     <ContentInterval begin="300" end="301" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:17">
+                     <ContentInterval begin="301" end="302" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:18">
+                     <ContentInterval begin="302" end="303" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[5:19]">
+                     <ContentInterval begin="303" end="304" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Trio in G-minor, for pianoforte, violin, and cello, op. 8">
+                  <Chunk label="5:20">
+                     <ContentInterval begin="304" end="305" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:21">
+                     <ContentInterval begin="305" end="306" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:22">
+                     <ContentInterval begin="306" end="307" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:23">
+                     <ContentInterval begin="307" end="308" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:24">
+                     <ContentInterval begin="308" end="309" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:25">
+                     <ContentInterval begin="309" end="310" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Studies form op. 10">
+                  <Chunk label="5:26">
+                     <ContentInterval begin="310" end="311" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:27">
+                     <ContentInterval begin="311" end="312" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:28">
+                     <ContentInterval begin="312" end="313" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:29">
+                     <ContentInterval begin="313" end="314" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Study in E-major, op. 10-3">
+                  <Chunk label="5:30">
+                     <ContentInterval begin="314" end="315" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:31">
+                     <ContentInterval begin="315" end="316" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Study in G-flat-major, op. 10-5">
+                  <Chunk label="5:32">
+                     <ContentInterval begin="316" end="317" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:33">
+                     <ContentInterval begin="317" end="318" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Study in E-flat-minor, op. 10-6">
+                  <Chunk label="5:34">
+                     <ContentInterval begin="318" end="319" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:35">
+                     <ContentInterval begin="319" end="320" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Study in F-major, op. 10-8">
+                  <Chunk label="5:36">
+                     <ContentInterval begin="320" end="321" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:37">
+                     <ContentInterval begin="321" end="322" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Study in F-minor, op. 10-9 and in A-flat-major, op. 10-10">
+                  <Chunk label="5:38">
+                     <ContentInterval begin="322" end="323" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:39">
+                     <ContentInterval begin="323" end="324" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:40">
+                     <ContentInterval begin="324" end="325" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:41">
+                     <ContentInterval begin="325" end="326" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:42">
+                     <ContentInterval begin="326" end="327" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:43">
+                     <ContentInterval begin="327" end="328" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Impromptu in A-flat-major, op. 29">
+                  <Chunk label="5:44">
+                     <ContentInterval begin="328" end="329" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:45">
+                     <ContentInterval begin="329" end="330" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:46">
+                     <ContentInterval begin="330" end="331" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:47">
+                     <ContentInterval begin="331" end="332" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Barcarolle in F-sharp-major, op. 60">
+                  <Chunk label="5:48">
+                     <ContentInterval begin="332" end="333" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:49">
+                     <ContentInterval begin="333" end="334" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:50">
+                     <ContentInterval begin="334" end="335" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:51">
+                     <ContentInterval begin="335" end="336" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:52">
+                     <ContentInterval begin="336" end="337" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:53">
+                     <ContentInterval begin="337" end="338" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:54">
+                     <ContentInterval begin="338" end="339" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:55">
+                     <ContentInterval begin="339" end="340" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:56">
+                     <ContentInterval begin="340" end="341" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:57">
+                     <ContentInterval begin="341" end="342" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:58">
+                     <ContentInterval begin="342" end="343" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[5:59]">
+                     <ContentInterval begin="343" end="344" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Polonaise-Fantasie in A-flat-major, op. 61">
+                  <Chunk label="5:60">
+                     <ContentInterval begin="344" end="345" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:61">
+                     <ContentInterval begin="345" end="346" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:62">
+                     <ContentInterval begin="346" end="347" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:63">
+                     <ContentInterval begin="347" end="348" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:64">
+                     <ContentInterval begin="348" end="349" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:65">
+                     <ContentInterval begin="349" end="350" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Polonaise in F-minor, op. 71-3">
+                  <Chunk label="5:66">
+                     <ContentInterval begin="350" end="351" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:67">
+                     <ContentInterval begin="351" end="352" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:68">
+                     <ContentInterval begin="352" end="353" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:69">
+                     <ContentInterval begin="353" end="354" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:70">
+                     <ContentInterval begin="354" end="355" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:71">
+                     <ContentInterval begin="355" end="356" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Song for voice and pianoforte, in A-flat-major, op. 74-10. &#34;The Warrior&#34;">
+                  <Chunk label="5:72">
+                     <ContentInterval begin="356" end="357" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:73">
+                     <ContentInterval begin="357" end="358" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:74">
+                     <ContentInterval begin="358" end="359" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:75">
+                     <ContentInterval begin="359" end="360" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[5:76]">
+                     <ContentInterval begin="360" end="361" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+            </Div>
+            <Div label="2. Sketches and fragments">
+               <Div label="[Half Title]">
+                  <Chunk label="[5:77]">
+                     <ContentInterval begin="361" end="362" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Berceuse in D-flat-major, op. 57">
+                  <Chunk label="5:78">
+                     <ContentInterval begin="362" end="363" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:79">
+                     <ContentInterval begin="363" end="364" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:80">
+                     <ContentInterval begin="364" end="365" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:81">
+                     <ContentInterval begin="365" end="366" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:82">
+                     <ContentInterval begin="366" end="367" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:83">
+                     <ContentInterval begin="367" end="368" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:84">
+                     <ContentInterval begin="368" end="369" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:85">
+                     <ContentInterval begin="369" end="370" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Sonata no. 3 in B-minor, op. 58">
+                  <Chunk label="5:86">
+                     <ContentInterval begin="370" end="371" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:87">
+                     <ContentInterval begin="371" end="372" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:88">
+                     <ContentInterval begin="372" end="373" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:89">
+                     <ContentInterval begin="373" end="374" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Barcarolle in F-sharp-major, op. 60">
+                  <Chunk label="5:90">
+                     <ContentInterval begin="374" end="375" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:91">
+                     <ContentInterval begin="375" end="376" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Polonaise-Fantasie in A-flat-major, op. 61">
+                  <Chunk label="5:92">
+                     <ContentInterval begin="376" end="377" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:93">
+                     <ContentInterval begin="377" end="378" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:94">
+                     <ContentInterval begin="378" end="379" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:95">
+                     <ContentInterval begin="379" end="380" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Sonata in G-minor, for pianoforte and cello, op. 65">
+                  <Chunk label="5:96">
+                     <ContentInterval begin="380" end="381" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:97">
+                     <ContentInterval begin="381" end="382" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:98">
+                     <ContentInterval begin="382" end="383" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:99">
+                     <ContentInterval begin="383" end="384" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:100">
+                     <ContentInterval begin="384" end="385" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:101">
+                     <ContentInterval begin="385" end="386" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:102">
+                     <ContentInterval begin="386" end="387" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:103">
+                     <ContentInterval begin="387" end="388" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:104">
+                     <ContentInterval begin="388" end="389" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:105">
+                     <ContentInterval begin="389" end="390" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:106">
+                     <ContentInterval begin="390" end="391" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:107">
+                     <ContentInterval begin="391" end="392" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:108">
+                     <ContentInterval begin="392" end="393" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:109">
+                     <ContentInterval begin="393" end="394" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:110">
+                     <ContentInterval begin="394" end="395" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:111">
+                     <ContentInterval begin="395" end="396" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:112">
+                     <ContentInterval begin="396" end="397" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:113">
+                     <ContentInterval begin="397" end="398" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Mazurka in F-minor, op. 68-4">
+                  <Chunk label="5:114">
+                     <ContentInterval begin="398" end="399" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:115">
+                     <ContentInterval begin="399" end="400" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:116">
+                     <ContentInterval begin="400" end="401" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:117">
+                     <ContentInterval begin="401" end="402" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:118">
+                     <ContentInterval begin="402" end="403" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:119">
+                     <ContentInterval begin="403" end="404" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Song for voice and pianoforte, op. 74-6. &#34;Out of my sight!&#34;">
+                  <Chunk label="5:120">
+                     <ContentInterval begin="404" end="405" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:121">
+                     <ContentInterval begin="405" end="406" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:122">
+                     <ContentInterval begin="406" end="407" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:123">
+                     <ContentInterval begin="407" end="408" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Song for voice and pianoforte, op. 74-14. &#34;The ring&#34;">
+                  <Chunk label="5:124">
+                     <ContentInterval begin="408" end="409" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:125">
+                     <ContentInterval begin="409" end="410" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:126">
+                     <ContentInterval begin="410" end="411" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:127">
+                     <ContentInterval begin="411" end="412" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Refrain of &#34;Dabrowski's Mazurka&#34;">
+                  <Chunk label="5:128">
+                     <ContentInterval begin="412" end="413" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:129">
+                     <ContentInterval begin="413" end="414" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:130">
+                     <ContentInterval begin="414" end="415" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:131">
+                     <ContentInterval begin="415" end="416" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Nocturne in C-minor">
+                  <Chunk label="5:132">
+                     <ContentInterval begin="416" end="417" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:133">
+                     <ContentInterval begin="417" end="418" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:134">
+                     <ContentInterval begin="418" end="419" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:135">
+                     <ContentInterval begin="419" end="420" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Sonata no. 2 in B-flat-minor, op. 35">
+                  <Chunk label="5:136">
+                     <ContentInterval begin="420" end="421" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:137">
+                     <ContentInterval begin="421" end="422" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Impromptu in F-sharp-major, op. 36">
+                  <Chunk label="5:138">
+                     <ContentInterval begin="422" end="423" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:139">
+                     <ContentInterval begin="423" end="424" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:140">
+                     <ContentInterval begin="424" end="425" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:141">
+                     <ContentInterval begin="425" end="426" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+               <Div label="Mazurka in G-major, op. 50-1">
+                  <Chunk label="5:142">
+                     <ContentInterval begin="426" end="427" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="5:143">
+                     <ContentInterval begin="427" end="428" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+                  <Chunk label="[5:144]">
+                     <ContentInterval begin="428" end="429" mediaRef="IU/MediaObject/446921"/>
+                  </Chunk>
+               </Div>
+            </Div>
+            <Div label="[Illustrations]">
+               <Chunk label="5:145">
+                  <ContentInterval begin="429" end="430" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="5:146">
+                  <ContentInterval begin="430" end="431" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+               <Chunk label="5:147">
+                  <ContentInterval begin="431" end="432" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+            <Div label="[Colophon]">
+               <Chunk label="[5:148]">
+                  <ContentInterval begin="432" end="433" mediaRef="IU/MediaObject/446921"/>
+               </Chunk>
+            </Div>
+         </Item>
+      </Structure>
+      <MediaObjectRefs>
+         <MediaObjectRef>IU/MediaObject/446921</MediaObjectRef>
+      </MediaObjectRefs>
+      <PhysicalID>
+         <Location>IU Music Library</Location>
+         <CallNumber>ML96.4 .C5 vol. 1-3, 5 (Vault)</CallNumber>
+         <CopyNumber>1</CopyNumber>
+      </PhysicalID>
+      <Condition/>
+      <HoldingStatus>Restricted access</HoldingStatus>
+      <CopyrightDecls>
+         <CopyrightDecl>
+            <Owner>(C) 1990 Fryderyk Chopin Society; Green Peace Pub.</Owner>
+            <Domain>Item</Domain>
+         </CopyrightDecl>
+      </CopyrightDecls>
+      <PublicDomain>Unknown</PublicDomain>
+      <OtherSystemIds>
+         <OtherSystemId>(Variations)abe9721</OtherSystemId>
+         <OtherSystemId>(InU)ABE9721BM</OtherSystemId>
+         <OtherSystemId>(OCoLC)ocm24634242</OtherSystemId>
+      </OtherSystemIds>
+      <Id>IU/Container/446566</Id>
+      <CreationInfo>
+         <User>epeebles@IU.EDU</User>
+         <Timestamp>2008-12-18 14:19:58.0</Timestamp>
+      </CreationInfo>
+      <UpdateInfo>
+         <User>ppagels@IU.EDU</User>
+         <Timestamp>2009-03-30 13:15:35.234</Timestamp>
+      </UpdateInfo>
+      <Status>Import only</Status>
+   </Container>
+   <SetInfo>
+      <TextMatches/>
+      <ThemeBaseURL>http://server1.variations2.indiana.edu/themes/</ThemeBaseURL>
+      <AvailableMediaItems>
+         <AllItemsAvailable>true</AllItemsAvailable>
+      </AvailableMediaItems>
+   </SetInfo>
+</RecordSet>
+</ScoreAccessPage>

--- a/spec/fixtures/variations_xml/abe9721.yml
+++ b/spec/fixtures/variations_xml/abe9721.yml
@@ -1,0 +1,4550 @@
+---
+:identifier: identifier
+:replaces: replaces
+:source_metadata_identifier: ABE9721
+:viewing_direction: right-to-left
+:thumbnail_path: "/tmp/MS-METS/bhr9405/abe9721-1-1.djvu"
+:volumes:
+- :id: ID GOES HERE
+  :title:
+  - 'The facsimil[e] edition of the autograph of Fryderyk Chopin''s works : from the
+    Collection Fryderyk Chopin Society in Warsaw, volume 1'
+  :nodes:
+  - :label: "[Contents]"
+    :nodes:
+    - :label: "[1:1]"
+      :proxy: abe9721-1-1.djvu
+  - :label: "[Mazurka in F-minor, op. 7-3]"
+    :nodes:
+    - :label: "[1:2]"
+      :proxy: abe9721-1-2.djvu
+    - :label: "[1:3]"
+      :proxy: abe9721-1-3.djvu
+    - :label: "[1:4]"
+      :proxy: abe9721-1-4.djvu
+    - :label: "[1:5]"
+      :proxy: abe9721-1-5.djvu
+  - :label: "[Trio in G-minor, for pianoforte, violin, cello, op. 8]"
+    :nodes:
+    - :label: "[1:6]"
+      :proxy: abe9721-1-6.djvu
+    - :label: "[1:7]"
+      :proxy: abe9721-1-7.djvu
+    - :label: "[1:8]"
+      :proxy: abe9721-1-8.djvu
+    - :label: "[1:9]"
+      :proxy: abe9721-1-9.djvu
+    - :label: "[1:10]"
+      :proxy: abe9721-1-10.djvu
+    - :label: "[1:11]"
+      :proxy: abe9721-1-11.djvu
+    - :label: "[1:12]"
+      :proxy: abe9721-1-12.djvu
+    - :label: "[1:13]"
+      :proxy: abe9721-1-13.djvu
+    - :label: "[1:14]"
+      :proxy: abe9721-1-14.djvu
+    - :label: "[1:15]"
+      :proxy: abe9721-1-15.djvu
+    - :label: "[1:16]"
+      :proxy: abe9721-1-16.djvu
+    - :label: "[1:17]"
+      :proxy: abe9721-1-17.djvu
+    - :label: "[1:18]"
+      :proxy: abe9721-1-18.djvu
+    - :label: "[1:19]"
+      :proxy: abe9721-1-19.djvu
+    - :label: "[1:20]"
+      :proxy: abe9721-1-20.djvu
+    - :label: "[1:21]"
+      :proxy: abe9721-1-21.djvu
+    - :label: "[1:22]"
+      :proxy: abe9721-1-22.djvu
+    - :label: "[1:23]"
+      :proxy: abe9721-1-23.djvu
+    - :label: "[1:24]"
+      :proxy: abe9721-1-24.djvu
+    - :label: "[1:25]"
+      :proxy: abe9721-1-25.djvu
+    - :label: "[1:26]"
+      :proxy: abe9721-1-26.djvu
+    - :label: "[1:27]"
+      :proxy: abe9721-1-27.djvu
+    - :label: "[1:28]"
+      :proxy: abe9721-1-28.djvu
+    - :label: "[1:29]"
+      :proxy: abe9721-1-29.djvu
+    - :label: "[1:30]"
+      :proxy: abe9721-1-30.djvu
+    - :label: "[1:31]"
+      :proxy: abe9721-1-31.djvu
+    - :label: "[1:32]"
+      :proxy: abe9721-1-32.djvu
+    - :label: "[1:33]"
+      :proxy: abe9721-1-33.djvu
+    - :label: "[1:34]"
+      :proxy: abe9721-1-34.djvu
+    - :label: "[1:35]"
+      :proxy: abe9721-1-35.djvu
+    - :label: "[1:36]"
+      :proxy: abe9721-1-36.djvu
+    - :label: "[1:37]"
+      :proxy: abe9721-1-37.djvu
+  - :label: "[Study in E-major, op. 10-3]"
+    :nodes:
+    - :label: "[1:38]"
+      :proxy: abe9721-1-38.djvu
+    - :label: "[1:39]"
+      :proxy: abe9721-1-39.djvu
+    - :label: "[1:40]"
+      :proxy: abe9721-1-40.djvu
+    - :label: "[1:41]"
+      :proxy: abe9721-1-41.djvu
+  - :label: "[Study in G-flat-major, op. 10-5]"
+    :nodes:
+    - :label: "[1:42]"
+      :proxy: abe9721-1-42.djvu
+    - :label: "[1:43]"
+      :proxy: abe9721-1-43.djvu
+    - :label: "[1:44]"
+      :proxy: abe9721-1-44.djvu
+    - :label: "[1:45]"
+      :proxy: abe9721-1-45.djvu
+  - :label: "[Study in E-flat-minor, op. 10-6]"
+    :nodes:
+    - :label: "[1:46]"
+      :proxy: abe9721-1-46.djvu
+    - :label: "[1:47]"
+      :proxy: abe9721-1-47.djvu
+    - :label: "[1:48]"
+      :proxy: abe9721-1-48.djvu
+    - :label: "[1:49]"
+      :proxy: abe9721-1-49.djvu
+  - :label: "[Study in F-major, op. 10-8]"
+    :nodes:
+    - :label: "[1:50]"
+      :proxy: abe9721-1-50.djvu
+    - :label: "[1:51]"
+      :proxy: abe9721-1-51.djvu
+    - :label: "[1:52]"
+      :proxy: abe9721-1-52.djvu
+    - :label: "[1:53]"
+      :proxy: abe9721-1-53.djvu
+    - :label: "[1:54]"
+      :proxy: abe9721-1-54.djvu
+    - :label: "[1:55]"
+      :proxy: abe9721-1-55.djvu
+  - :label: "[Study in F-minor, op. 10-9]"
+    :nodes:
+    - :label: "[1:56]"
+      :proxy: abe9721-1-56.djvu
+    - :label: "[1:57]"
+      :proxy: abe9721-1-57.djvu
+    - :label: "[1:58]"
+      :proxy: abe9721-1-58.djvu
+  - :label: "[Study in A-flat-major, op. 10-10]"
+    :nodes:
+    - :label: "[1:59]"
+      :proxy: abe9721-1-59.djvu
+    - :label: "[1:60]"
+      :proxy: abe9721-1-60.djvu
+    - :label: "[1:61]"
+      :proxy: abe9721-1-61.djvu
+    - :label: "[1:62]"
+      :proxy: abe9721-1-62.djvu
+    - :label: "[1:63]"
+      :proxy: abe9721-1-63.djvu
+  - :label: "[Studies, 1st ed.]"
+    :nodes:
+    - :label: "[Front cover]"
+      :nodes:
+      - :label: "[1:64]"
+        :proxy: abe9721-1-64.djvu
+      - :label: "[1:65]"
+        :proxy: abe9721-1-65.djvu
+    - :label: "[Study in C-major, op. 10-1, 1st ed.]"
+      :nodes:
+      - :label: "[1:66]"
+        :proxy: abe9721-1-66.djvu
+      - :label: "[1:67]"
+        :proxy: abe9721-1-67.djvu
+      - :label: "[1:68]"
+        :proxy: abe9721-1-68.djvu
+      - :label: "[1:69]"
+        :proxy: abe9721-1-69.djvu
+      - :label: "[1:70]"
+        :proxy: abe9721-1-70.djvu
+    - :label: "[Study in A-minor, op. 10-2, 1st ed.]"
+      :nodes:
+      - :label: "[1:71]"
+        :proxy: abe9721-1-71.djvu
+      - :label: "[1:72]"
+        :proxy: abe9721-1-72.djvu
+      - :label: "[1:73]"
+        :proxy: abe9721-1-73.djvu
+      - :label: "[1:74]"
+        :proxy: abe9721-1-74.djvu
+      - :label: "[1:75]"
+        :proxy: abe9721-1-75.djvu
+    - :label: "[Study in C-sharp-minor, op. 10-4, 1st ed.]"
+      :nodes:
+      - :label: "[1:76]"
+        :proxy: abe9721-1-76.djvu
+      - :label: "[1:77]"
+        :proxy: abe9721-1-77.djvu
+      - :label: "[1:78]"
+        :proxy: abe9721-1-78.djvu
+      - :label: "[1:79]"
+        :proxy: abe9721-1-79.djvu
+      - :label: "[1:80]"
+        :proxy: abe9721-1-80.djvu
+    - :label: "[Study in C-major, op. 10-7, 1st ed.]"
+      :nodes:
+      - :label: "[1:81]"
+        :proxy: abe9721-1-81.djvu
+      - :label: "[1:82]"
+        :proxy: abe9721-1-82.djvu
+      - :label: "[1:83]"
+        :proxy: abe9721-1-83.djvu
+      - :label: "[1:84]"
+        :proxy: abe9721-1-84.djvu
+    - :label: Study in E-flat-major, op 10-11, 1st ed.]
+      :nodes:
+      - :label: "[1:85]"
+        :proxy: abe9721-1-85.djvu
+      - :label: "[1:86]"
+        :proxy: abe9721-1-86.djvu
+      - :label: "[1:87]"
+        :proxy: abe9721-1-87.djvu
+    - :label: "[Study in C-minor, op. 10-12, 1st ed.]"
+      :nodes:
+      - :label: "[1:88]"
+        :proxy: abe9721-1-88.djvu
+      - :label: "[1:89]"
+        :proxy: abe9721-1-89.djvu
+      - :label: "[1:90]"
+        :proxy: abe9721-1-90.djvu
+      - :label: "[1:91]"
+        :proxy: abe9721-1-91.djvu
+      - :label: "[1:92]"
+        :proxy: abe9721-1-92.djvu
+      - :label: "[1:93]"
+        :proxy: abe9721-1-93.djvu
+  - :label: "[Impromptu in A-flat major, op. 29]"
+    :nodes:
+    - :label: "[1:94]"
+      :proxy: abe9721-1-94.djvu
+    - :label: "[1:95]"
+      :proxy: abe9721-1-95.djvu
+    - :label: "[1:96]"
+      :proxy: abe9721-1-96.djvu
+    - :label: "[1:97]"
+      :proxy: abe9721-1-97.djvu
+    - :label: "[1:98]"
+      :proxy: abe9721-1-98.djvu
+    - :label: "[1:99]"
+      :proxy: abe9721-1-99.djvu
+    - :label: "[1:100]"
+      :proxy: abe9721-1-100.djvu
+    - :label: "[1:101]"
+      :proxy: abe9721-1-101.djvu
+    - :label: "[1:102]"
+      :proxy: abe9721-1-102.djvu
+    - :label: "[1:103]"
+      :proxy: abe9721-1-103.djvu
+    - :label: "[1:104]"
+      :proxy: abe9721-1-104.djvu
+    - :label: "[1:105]"
+      :proxy: abe9721-1-105.djvu
+  - :label: "[Barcarolle in F-sharp-major, op. 60]"
+    :nodes:
+    - :label: "[1:106]"
+      :proxy: abe9721-1-106.djvu
+    - :label: "[1:107]"
+      :proxy: abe9721-1-107.djvu
+    - :label: "[1:108]"
+      :proxy: abe9721-1-108.djvu
+    - :label: "[1:109]"
+      :proxy: abe9721-1-109.djvu
+    - :label: "[1:110]"
+      :proxy: abe9721-1-110.djvu
+    - :label: "[1:111]"
+      :proxy: abe9721-1-111.djvu
+    - :label: "[1:112]"
+      :proxy: abe9721-1-112.djvu
+    - :label: "[1:113]"
+      :proxy: abe9721-1-113.djvu
+  - :label: "[Polonaise in F-mainor, op. 71-3]"
+    :nodes:
+    - :label: "[1:114]"
+      :proxy: abe9721-1-114.djvu
+    - :label: "[1:115]"
+      :proxy: abe9721-1-115.djvu
+    - :label: "[1:116]"
+      :proxy: abe9721-1-116.djvu
+    - :label: "[1:117]"
+      :proxy: abe9721-1-117.djvu
+    - :label: "[1:118]"
+      :proxy: abe9721-1-118.djvu
+    - :label: "[1:119]"
+      :proxy: abe9721-1-119.djvu
+  - :label: "[Polonaise-Fantasie in A-flat-major, op. 61]"
+    :nodes:
+    - :label: "[1:120]"
+      :proxy: abe9721-1-120.djvu
+    - :label: "[1:121]"
+      :proxy: abe9721-1-121.djvu
+    - :label: "[1:122]"
+      :proxy: abe9721-1-122.djvu
+    - :label: "[1:123]"
+      :proxy: abe9721-1-123.djvu
+    - :label: "[1:124]"
+      :proxy: abe9721-1-124.djvu
+    - :label: "[1:125]"
+      :proxy: abe9721-1-125.djvu
+    - :label: "[1:126]"
+      :proxy: abe9721-1-126.djvu
+    - :label: "[1:127]"
+      :proxy: abe9721-1-127.djvu
+  - :label: '[Song for voice and pianoforte, in A-flat-major, op. 74-10 "Wojak" (The
+      Warrior)]'
+    :nodes:
+    - :label: "[1:128]"
+      :proxy: abe9721-1-128.djvu
+    - :label: "[1:129]"
+      :proxy: abe9721-1-129.djvu
+  - :label: "[Colophon]"
+    :nodes:
+    - :label: "[1:130]"
+      :proxy: abe9721-1-130.djvu
+  :files:
+  - :id: abe9721-1-1.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-1.djvu"
+    :title:
+    - "[1:1]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-2.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-2.djvu"
+    :title:
+    - "[1:2]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-3.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-3.djvu"
+    :title:
+    - "[1:3]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-4.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-4.djvu"
+    :title:
+    - "[1:4]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-5.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-5.djvu"
+    :title:
+    - "[1:5]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-6.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-6.djvu"
+    :title:
+    - "[1:6]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-7.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-7.djvu"
+    :title:
+    - "[1:7]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-8.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-8.djvu"
+    :title:
+    - "[1:8]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-9.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-9.djvu"
+    :title:
+    - "[1:9]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-10.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-10.djvu"
+    :title:
+    - "[1:10]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-11.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-11.djvu"
+    :title:
+    - "[1:11]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-12.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-12.djvu"
+    :title:
+    - "[1:12]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-13.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-13.djvu"
+    :title:
+    - "[1:13]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-14.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-14.djvu"
+    :title:
+    - "[1:14]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-15.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-15.djvu"
+    :title:
+    - "[1:15]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-16.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-16.djvu"
+    :title:
+    - "[1:16]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-17.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-17.djvu"
+    :title:
+    - "[1:17]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-18.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-18.djvu"
+    :title:
+    - "[1:18]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-19.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-19.djvu"
+    :title:
+    - "[1:19]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-20.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-20.djvu"
+    :title:
+    - "[1:20]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-21.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-21.djvu"
+    :title:
+    - "[1:21]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-22.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-22.djvu"
+    :title:
+    - "[1:22]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-23.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-23.djvu"
+    :title:
+    - "[1:23]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-24.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-24.djvu"
+    :title:
+    - "[1:24]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-25.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-25.djvu"
+    :title:
+    - "[1:25]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-26.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-26.djvu"
+    :title:
+    - "[1:26]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-27.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-27.djvu"
+    :title:
+    - "[1:27]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-28.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-28.djvu"
+    :title:
+    - "[1:28]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-29.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-29.djvu"
+    :title:
+    - "[1:29]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-30.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-30.djvu"
+    :title:
+    - "[1:30]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-31.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-31.djvu"
+    :title:
+    - "[1:31]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-32.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-32.djvu"
+    :title:
+    - "[1:32]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-33.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-33.djvu"
+    :title:
+    - "[1:33]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-34.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-34.djvu"
+    :title:
+    - "[1:34]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-35.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-35.djvu"
+    :title:
+    - "[1:35]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-36.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-36.djvu"
+    :title:
+    - "[1:36]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-37.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-37.djvu"
+    :title:
+    - "[1:37]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-38.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-38.djvu"
+    :title:
+    - "[1:38]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-39.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-39.djvu"
+    :title:
+    - "[1:39]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-40.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-40.djvu"
+    :title:
+    - "[1:40]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-41.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-41.djvu"
+    :title:
+    - "[1:41]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-42.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-42.djvu"
+    :title:
+    - "[1:42]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-43.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-43.djvu"
+    :title:
+    - "[1:43]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-44.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-44.djvu"
+    :title:
+    - "[1:44]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-45.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-45.djvu"
+    :title:
+    - "[1:45]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-46.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-46.djvu"
+    :title:
+    - "[1:46]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-47.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-47.djvu"
+    :title:
+    - "[1:47]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-48.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-48.djvu"
+    :title:
+    - "[1:48]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-49.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-49.djvu"
+    :title:
+    - "[1:49]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-50.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-50.djvu"
+    :title:
+    - "[1:50]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-51.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-51.djvu"
+    :title:
+    - "[1:51]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-52.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-52.djvu"
+    :title:
+    - "[1:52]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-53.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-53.djvu"
+    :title:
+    - "[1:53]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-54.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-54.djvu"
+    :title:
+    - "[1:54]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-55.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-55.djvu"
+    :title:
+    - "[1:55]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-56.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-56.djvu"
+    :title:
+    - "[1:56]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-57.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-57.djvu"
+    :title:
+    - "[1:57]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-58.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-58.djvu"
+    :title:
+    - "[1:58]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-59.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-59.djvu"
+    :title:
+    - "[1:59]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-60.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-60.djvu"
+    :title:
+    - "[1:60]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-61.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-61.djvu"
+    :title:
+    - "[1:61]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-62.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-62.djvu"
+    :title:
+    - "[1:62]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-63.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-63.djvu"
+    :title:
+    - "[1:63]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-64.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-64.djvu"
+    :title:
+    - "[1:64]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-65.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-65.djvu"
+    :title:
+    - "[1:65]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-66.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-66.djvu"
+    :title:
+    - "[1:66]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-67.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-67.djvu"
+    :title:
+    - "[1:67]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-68.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-68.djvu"
+    :title:
+    - "[1:68]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-69.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-69.djvu"
+    :title:
+    - "[1:69]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-70.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-70.djvu"
+    :title:
+    - "[1:70]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-71.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-71.djvu"
+    :title:
+    - "[1:71]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-72.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-72.djvu"
+    :title:
+    - "[1:72]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-73.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-73.djvu"
+    :title:
+    - "[1:73]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-74.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-74.djvu"
+    :title:
+    - "[1:74]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-75.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-75.djvu"
+    :title:
+    - "[1:75]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-76.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-76.djvu"
+    :title:
+    - "[1:76]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-77.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-77.djvu"
+    :title:
+    - "[1:77]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-78.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-78.djvu"
+    :title:
+    - "[1:78]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-79.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-79.djvu"
+    :title:
+    - "[1:79]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-80.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-80.djvu"
+    :title:
+    - "[1:80]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-81.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-81.djvu"
+    :title:
+    - "[1:81]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-82.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-82.djvu"
+    :title:
+    - "[1:82]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-83.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-83.djvu"
+    :title:
+    - "[1:83]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-84.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-84.djvu"
+    :title:
+    - "[1:84]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-85.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-85.djvu"
+    :title:
+    - "[1:85]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-86.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-86.djvu"
+    :title:
+    - "[1:86]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-87.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-87.djvu"
+    :title:
+    - "[1:87]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-88.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-88.djvu"
+    :title:
+    - "[1:88]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-89.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-89.djvu"
+    :title:
+    - "[1:89]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-90.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-90.djvu"
+    :title:
+    - "[1:90]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-91.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-91.djvu"
+    :title:
+    - "[1:91]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-92.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-92.djvu"
+    :title:
+    - "[1:92]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-93.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-93.djvu"
+    :title:
+    - "[1:93]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-94.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-94.djvu"
+    :title:
+    - "[1:94]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-95.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-95.djvu"
+    :title:
+    - "[1:95]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-96.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-96.djvu"
+    :title:
+    - "[1:96]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-97.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-97.djvu"
+    :title:
+    - "[1:97]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-98.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-98.djvu"
+    :title:
+    - "[1:98]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-99.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-99.djvu"
+    :title:
+    - "[1:99]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-100.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-100.djvu"
+    :title:
+    - "[1:100]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-101.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-101.djvu"
+    :title:
+    - "[1:101]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-102.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-102.djvu"
+    :title:
+    - "[1:102]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-103.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-103.djvu"
+    :title:
+    - "[1:103]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-104.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-104.djvu"
+    :title:
+    - "[1:104]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-105.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-105.djvu"
+    :title:
+    - "[1:105]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-106.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-106.djvu"
+    :title:
+    - "[1:106]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-107.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-107.djvu"
+    :title:
+    - "[1:107]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-108.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-108.djvu"
+    :title:
+    - "[1:108]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-109.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-109.djvu"
+    :title:
+    - "[1:109]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-110.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-110.djvu"
+    :title:
+    - "[1:110]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-111.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-111.djvu"
+    :title:
+    - "[1:111]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-112.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-112.djvu"
+    :title:
+    - "[1:112]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-113.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-113.djvu"
+    :title:
+    - "[1:113]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-114.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-114.djvu"
+    :title:
+    - "[1:114]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-115.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-115.djvu"
+    :title:
+    - "[1:115]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-116.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-116.djvu"
+    :title:
+    - "[1:116]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-117.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-117.djvu"
+    :title:
+    - "[1:117]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-118.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-118.djvu"
+    :title:
+    - "[1:118]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-119.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-119.djvu"
+    :title:
+    - "[1:119]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-120.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-120.djvu"
+    :title:
+    - "[1:120]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-121.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-121.djvu"
+    :title:
+    - "[1:121]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-122.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-122.djvu"
+    :title:
+    - "[1:122]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-123.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-123.djvu"
+    :title:
+    - "[1:123]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-124.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-124.djvu"
+    :title:
+    - "[1:124]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-125.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-125.djvu"
+    :title:
+    - "[1:125]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-126.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-126.djvu"
+    :title:
+    - "[1:126]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-127.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-127.djvu"
+    :title:
+    - "[1:127]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-128.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-128.djvu"
+    :title:
+    - "[1:128]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-129.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-129.djvu"
+    :title:
+    - "[1:129]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-1-130.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-1-130.djvu"
+    :title:
+    - "[1:130]"
+    :replaces: replaces
+    :file_opts: {}
+- :id: ID GOES HERE
+  :title:
+  - 'The facsimil[e] edition of the autograph of Fryderyk Chopin''s works : from the
+    Collection Fryderyk Chopin Society in Warsaw, volume 2'
+  :nodes:
+  - :label: "[Contents]"
+    :nodes:
+    - :label: "[2:1]"
+      :proxy: abe9721-2-1.djvu
+  - :label: "[Berceuse in D-flat-major, op. 57]"
+    :nodes:
+    - :label: "[2:2]"
+      :proxy: abe9721-2-2.djvu
+    - :label: "[2:3]"
+      :proxy: abe9721-2-3.djvu
+    - :label: "[2:4]"
+      :proxy: abe9721-2-4.djvu
+    - :label: "[2:5]"
+      :proxy: abe9721-2-5.djvu
+  - :label: "[Sonata no. 3 in B-minor, op. 58]"
+    :nodes:
+    - :label: "[2:6]"
+      :proxy: abe9721-2-6.djvu
+    - :label: "[2:7]"
+      :proxy: abe9721-2-7.djvu
+  - :label: "[Barcarolle in F-sharp-major, op. 60]"
+    :nodes:
+    - :label: "[2:8]"
+      :proxy: abe9721-2-8.djvu
+    - :label: "[2:9]"
+      :proxy: abe9721-2-9.djvu
+  - :label: "[Polonaise-Fantasie in A-flat-major, op. 61]"
+    :nodes:
+    - :label: "[2:10]"
+      :proxy: abe9721-2-10.djvu
+    - :label: "[2:11]"
+      :proxy: abe9721-2-11.djvu
+  - :label: "[Sonata in G-minor, for pianoforte and cello, op. 65]"
+    :nodes:
+    - :label: "[2:12]"
+      :proxy: abe9721-2-12.djvu
+    - :label: "[2:13]"
+      :proxy: abe9721-2-13.djvu
+    - :label: "[2:14]"
+      :proxy: abe9721-2-14.djvu
+    - :label: "[2:15]"
+      :proxy: abe9721-2-15.djvu
+    - :label: "[2:16]"
+      :proxy: abe9721-2-16.djvu
+    - :label: "[2:17]"
+      :proxy: abe9721-2-17.djvu
+    - :label: "[2:18]"
+      :proxy: abe9721-2-18.djvu
+    - :label: "[2:19]"
+      :proxy: abe9721-2-19.djvu
+    - :label: "[2:20]"
+      :proxy: abe9721-2-20.djvu
+    - :label: "[2:21]"
+      :proxy: abe9721-2-21.djvu
+    - :label: "[2:22]"
+      :proxy: abe9721-2-22.djvu
+    - :label: "[2:23]"
+      :proxy: abe9721-2-23.djvu
+    - :label: "[2:24]"
+      :proxy: abe9721-2-24.djvu
+    - :label: "[2:25]"
+      :proxy: abe9721-2-25.djvu
+    - :label: "[2:26]"
+      :proxy: abe9721-2-26.djvu
+    - :label: "[2:27]"
+      :proxy: abe9721-2-27.djvu
+    - :label: "[2:28]"
+      :proxy: abe9721-2-28.djvu
+    - :label: "[2:29]"
+      :proxy: abe9721-2-29.djvu
+    - :label: "[2:30]"
+      :proxy: abe9721-2-30.djvu
+    - :label: "[2:31]"
+      :proxy: abe9721-2-31.djvu
+    - :label: "[2:32]"
+      :proxy: abe9721-2-32.djvu
+    - :label: "[2:33]"
+      :proxy: abe9721-2-33.djvu
+    - :label: "[2:34]"
+      :proxy: abe9721-2-34.djvu
+    - :label: "[2:35]"
+      :proxy: abe9721-2-35.djvu
+    - :label: "[2:36]"
+      :proxy: abe9721-2-36.djvu
+    - :label: "[2:37]"
+      :proxy: abe9721-2-37.djvu
+    - :label: "[2:38]"
+      :proxy: abe9721-2-38.djvu
+    - :label: "[2:39]"
+      :proxy: abe9721-2-39.djvu
+    - :label: "[2:40]"
+      :proxy: abe9721-2-40.djvu
+    - :label: "[2:41]"
+      :proxy: abe9721-2-41.djvu
+    - :label: "[2:42]"
+      :proxy: abe9721-2-42.djvu
+    - :label: "[2:43]"
+      :proxy: abe9721-2-43.djvu
+    - :label: "[2:44]"
+      :proxy: abe9721-2-44.djvu
+    - :label: "[2:45]"
+      :proxy: abe9721-2-45.djvu
+    - :label: "[2:46]"
+      :proxy: abe9721-2-46.djvu
+    - :label: "[2:47]"
+      :proxy: abe9721-2-47.djvu
+    - :label: "[2:48]"
+      :proxy: abe9721-2-48.djvu
+    - :label: "[2:49]"
+      :proxy: abe9721-2-49.djvu
+    - :label: "[2:50]"
+      :proxy: abe9721-2-50.djvu
+    - :label: "[2:51]"
+      :proxy: abe9721-2-51.djvu
+    - :label: "[2:52]"
+      :proxy: abe9721-2-52.djvu
+    - :label: "[2:53]"
+      :proxy: abe9721-2-53.djvu
+    - :label: "[2:54]"
+      :proxy: abe9721-2-54.djvu
+    - :label: "[2:55]"
+      :proxy: abe9721-2-55.djvu
+    - :label: "[2:56]"
+      :proxy: abe9721-2-56.djvu
+    - :label: "[2:57]"
+      :proxy: abe9721-2-57.djvu
+    - :label: "[2:58]"
+      :proxy: abe9721-2-58.djvu
+    - :label: "[2:59]"
+      :proxy: abe9721-2-59.djvu
+    - :label: "[2:60]"
+      :proxy: abe9721-2-60.djvu
+    - :label: "[2:61]"
+      :proxy: abe9721-2-61.djvu
+    - :label: "[2:62]"
+      :proxy: abe9721-2-62.djvu
+    - :label: "[2:63]"
+      :proxy: abe9721-2-63.djvu
+    - :label: "[2:64]"
+      :proxy: abe9721-2-64.djvu
+    - :label: "[2:65]"
+      :proxy: abe9721-2-65.djvu
+    - :label: "[2:66]"
+      :proxy: abe9721-2-66.djvu
+    - :label: "[2:67]"
+      :proxy: abe9721-2-67.djvu
+    - :label: "[2:68]"
+      :proxy: abe9721-2-68.djvu
+    - :label: "[2:69]"
+      :proxy: abe9721-2-69.djvu
+    - :label: "[2:70]"
+      :proxy: abe9721-2-70.djvu
+    - :label: "[2:71]"
+      :proxy: abe9721-2-71.djvu
+    - :label: "[2:72]"
+      :proxy: abe9721-2-72.djvu
+    - :label: "[2:73]"
+      :proxy: abe9721-2-73.djvu
+    - :label: "[2:74]"
+      :proxy: abe9721-2-74.djvu
+    - :label: "[2:75]"
+      :proxy: abe9721-2-75.djvu
+    - :label: "[2:76]"
+      :proxy: abe9721-2-76.djvu
+    - :label: "[2:77]"
+      :proxy: abe9721-2-77.djvu
+    - :label: "[2:78]"
+      :proxy: abe9721-2-78.djvu
+    - :label: "[2:79]"
+      :proxy: abe9721-2-79.djvu
+  - :label: "[Mazurka in F-minor, op. 68-4]"
+    :nodes:
+    - :label: "[2:80]"
+      :proxy: abe9721-2-80.djvu
+    - :label: "[2:81]"
+      :proxy: abe9721-2-81.djvu
+  - :label: '[Song for voice and pianoforte, in A-minor, op. 74-6. "Precz z moich
+      oczu" (Out of my sight)'
+    :nodes:
+    - :label: "[2:82]"
+      :proxy: abe9721-2-82.djvu
+    - :label: "[2:83]"
+      :proxy: abe9721-2-83.djvu
+  - :label: '[Song for voice and pianoforte, in E-flat-major, op. 74-14. "Pierscien"
+      (The ring)'
+    :nodes:
+    - :label: "[2:84]"
+      :proxy: abe9721-2-84.djvu
+    - :label: "[2:85]"
+      :proxy: abe9721-2-85.djvu
+  - :label: '[Song in F-major, "Dawniej polak--"]'
+    :nodes:
+    - :label: "[2:86]"
+      :proxy: abe9721-2-86.djvu
+    - :label: "[2:87]"
+      :proxy: abe9721-2-87.djvu
+  - :label: '[Refrain of "Dabrowski''s Mazurka"]'
+    :nodes:
+    - :label: "[2:88]"
+      :proxy: abe9721-2-88.djvu
+    - :label: "[2:89]"
+      :proxy: abe9721-2-89.djvu
+  - :label: "[Nocturne in C-minor]"
+    :nodes:
+    - :label: "[2:90]"
+      :proxy: abe9721-2-90.djvu
+    - :label: "[2:91]"
+      :proxy: abe9721-2-91.djvu
+  - :label: "[Sonata no. 2 in B-flat-minor, op. 35]"
+    :nodes:
+    - :label: "[2:92]"
+      :proxy: abe9721-2-92.djvu
+    - :label: "[2:93]"
+      :proxy: abe9721-2-93.djvu
+  - :label: "[Impromptu in F-sharp-major, op. 36]"
+    :nodes:
+    - :label: "[2:94]"
+      :proxy: abe9721-2-94.djvu
+    - :label: "[2:95]"
+      :proxy: abe9721-2-95.djvu
+  - :label: "[Mazurka in G-major, op. 50-1]"
+    :nodes:
+    - :label: "[2:96]"
+      :proxy: abe9721-2-96.djvu
+    - :label: "[2:97]"
+      :proxy: abe9721-2-97.djvu
+  - :label: "[Sonata no. 2 in B-flat-minor, op. 35, 1st ed.]"
+    :nodes:
+    - :label: "[2:98]"
+      :proxy: abe9721-2-98.djvu
+    - :label: "[2:99]"
+      :proxy: abe9721-2-99.djvu
+    - :label: "[2:100]"
+      :proxy: abe9721-2-100.djvu
+    - :label: "[2:101]"
+      :proxy: abe9721-2-101.djvu
+    - :label: "[2:102]"
+      :proxy: abe9721-2-102.djvu
+    - :label: "[2:103]"
+      :proxy: abe9721-2-103.djvu
+    - :label: "[2:104]"
+      :proxy: abe9721-2-104.djvu
+    - :label: "[2:105]"
+      :proxy: abe9721-2-105.djvu
+    - :label: "[2:106]"
+      :proxy: abe9721-2-106.djvu
+    - :label: "[2:107]"
+      :proxy: abe9721-2-107.djvu
+    - :label: "[2:108]"
+      :proxy: abe9721-2-108.djvu
+    - :label: "[2:109]"
+      :proxy: abe9721-2-109.djvu
+    - :label: "[2:110]"
+      :proxy: abe9721-2-110.djvu
+    - :label: "[2:111]"
+      :proxy: abe9721-2-111.djvu
+    - :label: "[2:112]"
+      :proxy: abe9721-2-112.djvu
+    - :label: "[2:113]"
+      :proxy: abe9721-2-113.djvu
+    - :label: "[2:114]"
+      :proxy: abe9721-2-114.djvu
+    - :label: "[2:115]"
+      :proxy: abe9721-2-115.djvu
+    - :label: "[2:116]"
+      :proxy: abe9721-2-116.djvu
+    - :label: "[2:117]"
+      :proxy: abe9721-2-117.djvu
+    - :label: "[2:118]"
+      :proxy: abe9721-2-118.djvu
+    - :label: "[2:119]"
+      :proxy: abe9721-2-119.djvu
+    - :label: "[2:120]"
+      :proxy: abe9721-2-120.djvu
+    - :label: "[2:121]"
+      :proxy: abe9721-2-121.djvu
+  - :label: "[Colophon]"
+    :nodes:
+    - :label: "[2:122]"
+      :proxy: abe9721-2-122.djvu
+  :files:
+  - :id: abe9721-2-1.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-1.djvu"
+    :title:
+    - "[2:1]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-2.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-2.djvu"
+    :title:
+    - "[2:2]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-3.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-3.djvu"
+    :title:
+    - "[2:3]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-4.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-4.djvu"
+    :title:
+    - "[2:4]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-5.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-5.djvu"
+    :title:
+    - "[2:5]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-6.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-6.djvu"
+    :title:
+    - "[2:6]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-7.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-7.djvu"
+    :title:
+    - "[2:7]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-8.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-8.djvu"
+    :title:
+    - "[2:8]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-9.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-9.djvu"
+    :title:
+    - "[2:9]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-10.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-10.djvu"
+    :title:
+    - "[2:10]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-11.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-11.djvu"
+    :title:
+    - "[2:11]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-12.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-12.djvu"
+    :title:
+    - "[2:12]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-13.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-13.djvu"
+    :title:
+    - "[2:13]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-14.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-14.djvu"
+    :title:
+    - "[2:14]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-15.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-15.djvu"
+    :title:
+    - "[2:15]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-16.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-16.djvu"
+    :title:
+    - "[2:16]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-17.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-17.djvu"
+    :title:
+    - "[2:17]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-18.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-18.djvu"
+    :title:
+    - "[2:18]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-19.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-19.djvu"
+    :title:
+    - "[2:19]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-20.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-20.djvu"
+    :title:
+    - "[2:20]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-21.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-21.djvu"
+    :title:
+    - "[2:21]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-22.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-22.djvu"
+    :title:
+    - "[2:22]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-23.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-23.djvu"
+    :title:
+    - "[2:23]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-24.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-24.djvu"
+    :title:
+    - "[2:24]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-25.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-25.djvu"
+    :title:
+    - "[2:25]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-26.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-26.djvu"
+    :title:
+    - "[2:26]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-27.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-27.djvu"
+    :title:
+    - "[2:27]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-28.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-28.djvu"
+    :title:
+    - "[2:28]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-29.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-29.djvu"
+    :title:
+    - "[2:29]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-30.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-30.djvu"
+    :title:
+    - "[2:30]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-31.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-31.djvu"
+    :title:
+    - "[2:31]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-32.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-32.djvu"
+    :title:
+    - "[2:32]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-33.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-33.djvu"
+    :title:
+    - "[2:33]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-34.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-34.djvu"
+    :title:
+    - "[2:34]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-35.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-35.djvu"
+    :title:
+    - "[2:35]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-36.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-36.djvu"
+    :title:
+    - "[2:36]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-37.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-37.djvu"
+    :title:
+    - "[2:37]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-38.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-38.djvu"
+    :title:
+    - "[2:38]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-39.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-39.djvu"
+    :title:
+    - "[2:39]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-40.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-40.djvu"
+    :title:
+    - "[2:40]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-41.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-41.djvu"
+    :title:
+    - "[2:41]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-42.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-42.djvu"
+    :title:
+    - "[2:42]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-43.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-43.djvu"
+    :title:
+    - "[2:43]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-44.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-44.djvu"
+    :title:
+    - "[2:44]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-45.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-45.djvu"
+    :title:
+    - "[2:45]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-46.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-46.djvu"
+    :title:
+    - "[2:46]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-47.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-47.djvu"
+    :title:
+    - "[2:47]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-48.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-48.djvu"
+    :title:
+    - "[2:48]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-49.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-49.djvu"
+    :title:
+    - "[2:49]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-50.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-50.djvu"
+    :title:
+    - "[2:50]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-51.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-51.djvu"
+    :title:
+    - "[2:51]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-52.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-52.djvu"
+    :title:
+    - "[2:52]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-53.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-53.djvu"
+    :title:
+    - "[2:53]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-54.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-54.djvu"
+    :title:
+    - "[2:54]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-55.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-55.djvu"
+    :title:
+    - "[2:55]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-56.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-56.djvu"
+    :title:
+    - "[2:56]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-57.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-57.djvu"
+    :title:
+    - "[2:57]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-58.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-58.djvu"
+    :title:
+    - "[2:58]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-59.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-59.djvu"
+    :title:
+    - "[2:59]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-60.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-60.djvu"
+    :title:
+    - "[2:60]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-61.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-61.djvu"
+    :title:
+    - "[2:61]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-62.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-62.djvu"
+    :title:
+    - "[2:62]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-63.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-63.djvu"
+    :title:
+    - "[2:63]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-64.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-64.djvu"
+    :title:
+    - "[2:64]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-65.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-65.djvu"
+    :title:
+    - "[2:65]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-66.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-66.djvu"
+    :title:
+    - "[2:66]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-67.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-67.djvu"
+    :title:
+    - "[2:67]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-68.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-68.djvu"
+    :title:
+    - "[2:68]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-69.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-69.djvu"
+    :title:
+    - "[2:69]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-70.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-70.djvu"
+    :title:
+    - "[2:70]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-71.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-71.djvu"
+    :title:
+    - "[2:71]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-72.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-72.djvu"
+    :title:
+    - "[2:72]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-73.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-73.djvu"
+    :title:
+    - "[2:73]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-74.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-74.djvu"
+    :title:
+    - "[2:74]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-75.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-75.djvu"
+    :title:
+    - "[2:75]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-76.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-76.djvu"
+    :title:
+    - "[2:76]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-77.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-77.djvu"
+    :title:
+    - "[2:77]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-78.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-78.djvu"
+    :title:
+    - "[2:78]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-79.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-79.djvu"
+    :title:
+    - "[2:79]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-80.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-80.djvu"
+    :title:
+    - "[2:80]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-81.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-81.djvu"
+    :title:
+    - "[2:81]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-82.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-82.djvu"
+    :title:
+    - "[2:82]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-83.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-83.djvu"
+    :title:
+    - "[2:83]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-84.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-84.djvu"
+    :title:
+    - "[2:84]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-85.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-85.djvu"
+    :title:
+    - "[2:85]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-86.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-86.djvu"
+    :title:
+    - "[2:86]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-87.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-87.djvu"
+    :title:
+    - "[2:87]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-88.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-88.djvu"
+    :title:
+    - "[2:88]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-89.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-89.djvu"
+    :title:
+    - "[2:89]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-90.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-90.djvu"
+    :title:
+    - "[2:90]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-91.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-91.djvu"
+    :title:
+    - "[2:91]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-92.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-92.djvu"
+    :title:
+    - "[2:92]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-93.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-93.djvu"
+    :title:
+    - "[2:93]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-94.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-94.djvu"
+    :title:
+    - "[2:94]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-95.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-95.djvu"
+    :title:
+    - "[2:95]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-96.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-96.djvu"
+    :title:
+    - "[2:96]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-97.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-97.djvu"
+    :title:
+    - "[2:97]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-98.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-98.djvu"
+    :title:
+    - "[2:98]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-99.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-99.djvu"
+    :title:
+    - "[2:99]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-100.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-100.djvu"
+    :title:
+    - "[2:100]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-101.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-101.djvu"
+    :title:
+    - "[2:101]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-102.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-102.djvu"
+    :title:
+    - "[2:102]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-103.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-103.djvu"
+    :title:
+    - "[2:103]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-104.djvu
+    :checksum: KRofxQUapZF9FfCRBE2Szw==
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-104.djvu"
+    :title:
+    - "[2:104]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-105.djvu
+    :checksum: SPReAxcqLYaQnAhXBiootQ==
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-105.djvu"
+    :title:
+    - "[2:105]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-106.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-106.djvu"
+    :title:
+    - "[2:106]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-107.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-107.djvu"
+    :title:
+    - "[2:107]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-108.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-108.djvu"
+    :title:
+    - "[2:108]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-109.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-109.djvu"
+    :title:
+    - "[2:109]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-110.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-110.djvu"
+    :title:
+    - "[2:110]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-111.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-111.djvu"
+    :title:
+    - "[2:111]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-112.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-112.djvu"
+    :title:
+    - "[2:112]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-113.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-113.djvu"
+    :title:
+    - "[2:113]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-114.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-114.djvu"
+    :title:
+    - "[2:114]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-115.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-115.djvu"
+    :title:
+    - "[2:115]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-116.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-116.djvu"
+    :title:
+    - "[2:116]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-117.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-117.djvu"
+    :title:
+    - "[2:117]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-118.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-118.djvu"
+    :title:
+    - "[2:118]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-119.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-119.djvu"
+    :title:
+    - "[2:119]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-120.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-120.djvu"
+    :title:
+    - "[2:120]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-121.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-121.djvu"
+    :title:
+    - "[2:121]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-2-122.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-2-122.djvu"
+    :title:
+    - "[2:122]"
+    :replaces: replaces
+    :file_opts: {}
+- :id: ID GOES HERE
+  :title:
+  - 'The facsimil[e] edition of the autograph of Fryderyk Chopin''s works : from the
+    Collection Fryderyk Chopin Society in Warsaw, volume 3'
+  :nodes:
+  - :label: "[Cover Page]"
+    :nodes:
+    - :label: "[3:1]"
+      :proxy: abe9721-3-1.djvu
+  - :label: "[Photograph]"
+    :nodes:
+    - :label: "[3:2]"
+      :proxy: abe9721-3-2.djvu
+    - :label: "[3:3]"
+      :proxy: abe9721-3-3.djvu
+  - :label: "[Description of photographs]"
+    :nodes:
+    - :label: "[3:4]"
+      :proxy: abe9721-3-4.djvu
+  - :label: "[Autograph]"
+    :nodes:
+    - :label: "[3:5]"
+      :proxy: abe9721-3-5.djvu
+  - :label: "[Series Title]"
+    :nodes:
+    - :label: "[3:6]"
+      :proxy: abe9721-3-6.djvu
+    - :label: "[3:7]"
+      :proxy: abe9721-3-7.djvu
+  - :label: "[Title Page]"
+    :nodes:
+    - :label: "[3:8]"
+      :proxy: abe9721-3-8.djvu
+    - :label: "[3:9]"
+      :proxy: abe9721-3-9.djvu
+  - :label: "[Acknowledgements]"
+    :nodes:
+    - :label: "[3:10]"
+      :proxy: abe9721-3-10.djvu
+  - :label: "[Portrait]"
+    :nodes:
+    - :label: "[3:11]"
+      :proxy: abe9721-3-11.djvu
+    - :label: "[3:12]"
+      :proxy: abe9721-3-12.djvu
+  - :label: "[Quote]"
+    :nodes:
+    - :label: "[3:13]"
+      :proxy: abe9721-3-13.djvu
+    - :label: "[3:14]"
+      :proxy: abe9721-3-14.djvu
+  - :label: "[Notes]"
+    :nodes:
+    - :label: "[3:15]"
+      :proxy: abe9721-3-15.djvu
+    - :label: "[3:16]"
+      :proxy: abe9721-3-16.djvu
+    - :label: "[3:17]"
+      :proxy: abe9721-3-17.djvu
+    - :label: "[3:18]"
+      :proxy: abe9721-3-18.djvu
+    - :label: "[3:19]"
+      :proxy: abe9721-3-19.djvu
+    - :label: "[3:20]"
+      :proxy: abe9721-3-20.djvu
+    - :label: "[3:21]"
+      :proxy: abe9721-3-21.djvu
+    - :label: "[3:22]"
+      :proxy: abe9721-3-22.djvu
+    - :label: "[3:23]"
+      :proxy: abe9721-3-23.djvu
+    - :label: "[3:24]"
+      :proxy: abe9721-3-24.djvu
+  - :label: "[Polonaise in G minor, 1817, 1st ed.]"
+    :nodes:
+    - :label: "[3:25]"
+      :proxy: abe9721-3-25.djvu
+    - :label: "[3:26]"
+      :proxy: abe9721-3-26.djvu
+    - :label: "[3:27]"
+      :proxy: abe9721-3-27.djvu
+    - :label: "[3:28]"
+      :proxy: abe9721-3-28.djvu
+    - :label: "[3:29]"
+      :proxy: abe9721-3-29.djvu
+  - :label: "[Colophon]"
+    :nodes:
+    - :label: "[3:30]"
+      :proxy: abe9721-3-30.djvu
+  - :label: "[Photograph]"
+    :nodes:
+    - :label: "[3:31]"
+      :proxy: abe9721-3-31.djvu
+    - :label: "[3:32]"
+      :proxy: abe9721-3-32.djvu
+  - :label: "[Back Cover]"
+    :nodes:
+    - :label: "[3:33]"
+      :proxy: abe9721-3-33.djvu
+  :files:
+  - :id: abe9721-3-1.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-1.djvu"
+    :title:
+    - "[3:1]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-2.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-2.djvu"
+    :title:
+    - "[3:2]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-3.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-3.djvu"
+    :title:
+    - "[3:3]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-4.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-4.djvu"
+    :title:
+    - "[3:4]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-5.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-5.djvu"
+    :title:
+    - "[3:5]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-6.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-6.djvu"
+    :title:
+    - "[3:6]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-7.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-7.djvu"
+    :title:
+    - "[3:7]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-8.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-8.djvu"
+    :title:
+    - "[3:8]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-9.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-9.djvu"
+    :title:
+    - "[3:9]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-10.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-10.djvu"
+    :title:
+    - "[3:10]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-11.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-11.djvu"
+    :title:
+    - "[3:11]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-12.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-12.djvu"
+    :title:
+    - "[3:12]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-13.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-13.djvu"
+    :title:
+    - "[3:13]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-14.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-14.djvu"
+    :title:
+    - "[3:14]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-15.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-15.djvu"
+    :title:
+    - "[3:15]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-16.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-16.djvu"
+    :title:
+    - "[3:16]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-17.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-17.djvu"
+    :title:
+    - "[3:17]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-18.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-18.djvu"
+    :title:
+    - "[3:18]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-19.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-19.djvu"
+    :title:
+    - "[3:19]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-20.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-20.djvu"
+    :title:
+    - "[3:20]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-21.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-21.djvu"
+    :title:
+    - "[3:21]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-22.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-22.djvu"
+    :title:
+    - "[3:22]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-23.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-23.djvu"
+    :title:
+    - "[3:23]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-24.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-24.djvu"
+    :title:
+    - "[3:24]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-25.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-25.djvu"
+    :title:
+    - "[3:25]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-26.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-26.djvu"
+    :title:
+    - "[3:26]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-27.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-27.djvu"
+    :title:
+    - "[3:27]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-28.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-28.djvu"
+    :title:
+    - "[3:28]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-29.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-29.djvu"
+    :title:
+    - "[3:29]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-30.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-30.djvu"
+    :title:
+    - "[3:30]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-31.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-31.djvu"
+    :title:
+    - "[3:31]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-32.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-32.djvu"
+    :title:
+    - "[3:32]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-3-33.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-3-33.djvu"
+    :title:
+    - "[3:33]"
+    :replaces: replaces
+    :file_opts: {}
+- :id: ID GOES HERE
+  :title:
+  - 'A commentary on the facsimil[e] edition of the autograph of Fryderyk Chopin''s
+    works : from the Collection Fryderyk Chopin Society in Warsaw, volume 5'
+  :nodes:
+  - :label: "[Title Page]"
+    :nodes:
+    - :label: "[5:1]"
+      :proxy: abe9721-5-1.djvu
+  - :label: "[Foreword]"
+    :nodes:
+    - :label: "[5:2]"
+      :proxy: abe9721-5-2.djvu
+    - :label: "[5:3]"
+      :proxy: abe9721-5-3.djvu
+    - :label: "[5:4]"
+      :proxy: abe9721-5-4.djvu
+    - :label: "[5:5]"
+      :proxy: abe9721-5-5.djvu
+    - :label: "[5:6]"
+      :proxy: abe9721-5-6.djvu
+    - :label: "[5:7]"
+      :proxy: abe9721-5-7.djvu
+  - :label: "[Contents]"
+    :nodes:
+    - :label: "[5:8]"
+      :proxy: abe9721-5-8.djvu
+    - :label: "[5:9]"
+      :proxy: abe9721-5-9.djvu
+  - :label: "[Acknowledgements and photographs]"
+    :nodes:
+    - :label: "[5:10]"
+      :proxy: abe9721-5-10.djvu
+    - :label: "[5:11]"
+      :proxy: abe9721-5-11.djvu
+  - :label: "[Quotes]"
+    :nodes:
+    - :label: "[5:12]"
+      :proxy: abe9721-5-12.djvu
+  - :label: 1. Complete compositions
+    :nodes:
+    - :label: "[Half Title]"
+      :nodes:
+      - :label: "[5:13]"
+        :proxy: abe9721-5-13.djvu
+    - :label: Mazurka in F-minor, op. 7-3
+      :nodes:
+      - :label: '5:14'
+        :proxy: abe9721-5-14.djvu
+      - :label: '5:15'
+        :proxy: abe9721-5-15.djvu
+      - :label: '5:16'
+        :proxy: abe9721-5-16.djvu
+      - :label: '5:17'
+        :proxy: abe9721-5-17.djvu
+      - :label: '5:18'
+        :proxy: abe9721-5-18.djvu
+      - :label: "[5:19]"
+        :proxy: abe9721-5-19.djvu
+    - :label: Trio in G-minor, for pianoforte, violin, and cello, op. 8
+      :nodes:
+      - :label: '5:20'
+        :proxy: abe9721-5-20.djvu
+      - :label: '5:21'
+        :proxy: abe9721-5-21.djvu
+      - :label: '5:22'
+        :proxy: abe9721-5-22.djvu
+      - :label: '5:23'
+        :proxy: abe9721-5-23.djvu
+      - :label: '5:24'
+        :proxy: abe9721-5-24.djvu
+      - :label: '5:25'
+        :proxy: abe9721-5-25.djvu
+    - :label: Studies form op. 10
+      :nodes:
+      - :label: '5:26'
+        :proxy: abe9721-5-26.djvu
+      - :label: '5:27'
+        :proxy: abe9721-5-27.djvu
+      - :label: '5:28'
+        :proxy: abe9721-5-28.djvu
+      - :label: '5:29'
+        :proxy: abe9721-5-29.djvu
+    - :label: Study in E-major, op. 10-3
+      :nodes:
+      - :label: '5:30'
+        :proxy: abe9721-5-30.djvu
+      - :label: '5:31'
+        :proxy: abe9721-5-31.djvu
+    - :label: Study in G-flat-major, op. 10-5
+      :nodes:
+      - :label: '5:32'
+        :proxy: abe9721-5-32.djvu
+      - :label: '5:33'
+        :proxy: abe9721-5-33.djvu
+    - :label: Study in E-flat-minor, op. 10-6
+      :nodes:
+      - :label: '5:34'
+        :proxy: abe9721-5-34.djvu
+      - :label: '5:35'
+        :proxy: abe9721-5-35.djvu
+    - :label: Study in F-major, op. 10-8
+      :nodes:
+      - :label: '5:36'
+        :proxy: abe9721-5-36.djvu
+      - :label: '5:37'
+        :proxy: abe9721-5-37.djvu
+    - :label: Study in F-minor, op. 10-9 and in A-flat-major, op. 10-10
+      :nodes:
+      - :label: '5:38'
+        :proxy: abe9721-5-38.djvu
+      - :label: '5:39'
+        :proxy: abe9721-5-39.djvu
+      - :label: '5:40'
+        :proxy: abe9721-5-40.djvu
+      - :label: '5:41'
+        :proxy: abe9721-5-41.djvu
+      - :label: '5:42'
+        :proxy: abe9721-5-42.djvu
+      - :label: '5:43'
+        :proxy: abe9721-5-43.djvu
+    - :label: Impromptu in A-flat-major, op. 29
+      :nodes:
+      - :label: '5:44'
+        :proxy: abe9721-5-44.djvu
+      - :label: '5:45'
+        :proxy: abe9721-5-45.djvu
+      - :label: '5:46'
+        :proxy: abe9721-5-46.djvu
+      - :label: '5:47'
+        :proxy: abe9721-5-47.djvu
+    - :label: Barcarolle in F-sharp-major, op. 60
+      :nodes:
+      - :label: '5:48'
+        :proxy: abe9721-5-48.djvu
+      - :label: '5:49'
+        :proxy: abe9721-5-49.djvu
+      - :label: '5:50'
+        :proxy: abe9721-5-50.djvu
+      - :label: '5:51'
+        :proxy: abe9721-5-51.djvu
+      - :label: '5:52'
+        :proxy: abe9721-5-52.djvu
+      - :label: '5:53'
+        :proxy: abe9721-5-53.djvu
+      - :label: '5:54'
+        :proxy: abe9721-5-54.djvu
+      - :label: '5:55'
+        :proxy: abe9721-5-55.djvu
+      - :label: '5:56'
+        :proxy: abe9721-5-56.djvu
+      - :label: '5:57'
+        :proxy: abe9721-5-57.djvu
+      - :label: '5:58'
+        :proxy: abe9721-5-58.djvu
+      - :label: "[5:59]"
+        :proxy: abe9721-5-59.djvu
+    - :label: Polonaise-Fantasie in A-flat-major, op. 61
+      :nodes:
+      - :label: 5:60
+        :proxy: abe9721-5-60.djvu
+      - :label: 5:61
+        :proxy: abe9721-5-61.djvu
+      - :label: 5:62
+        :proxy: abe9721-5-62.djvu
+      - :label: 5:63
+        :proxy: abe9721-5-63.djvu
+      - :label: 5:64
+        :proxy: abe9721-5-64.djvu
+      - :label: 5:65
+        :proxy: abe9721-5-65.djvu
+    - :label: Polonaise in F-minor, op. 71-3
+      :nodes:
+      - :label: 5:66
+        :proxy: abe9721-5-66.djvu
+      - :label: 5:67
+        :proxy: abe9721-5-67.djvu
+      - :label: 5:68
+        :proxy: abe9721-5-68.djvu
+      - :label: 5:69
+        :proxy: abe9721-5-69.djvu
+      - :label: 5:70
+        :proxy: abe9721-5-70.djvu
+      - :label: 5:71
+        :proxy: abe9721-5-71.djvu
+    - :label: Song for voice and pianoforte, in A-flat-major, op. 74-10. "The Warrior"
+      :nodes:
+      - :label: 5:72
+        :proxy: abe9721-5-72.djvu
+      - :label: 5:73
+        :proxy: abe9721-5-73.djvu
+      - :label: 5:74
+        :proxy: abe9721-5-74.djvu
+      - :label: 5:75
+        :proxy: abe9721-5-75.djvu
+      - :label: "[5:76]"
+        :proxy: abe9721-5-76.djvu
+  - :label: 2. Sketches and fragments
+    :nodes:
+    - :label: "[Half Title]"
+      :nodes:
+      - :label: "[5:77]"
+        :proxy: abe9721-5-77.djvu
+    - :label: Berceuse in D-flat-major, op. 57
+      :nodes:
+      - :label: 5:78
+        :proxy: abe9721-5-78.djvu
+      - :label: 5:79
+        :proxy: abe9721-5-79.djvu
+      - :label: 5:80
+        :proxy: abe9721-5-80.djvu
+      - :label: 5:81
+        :proxy: abe9721-5-81.djvu
+      - :label: 5:82
+        :proxy: abe9721-5-82.djvu
+      - :label: 5:83
+        :proxy: abe9721-5-83.djvu
+      - :label: 5:84
+        :proxy: abe9721-5-84.djvu
+      - :label: 5:85
+        :proxy: abe9721-5-85.djvu
+    - :label: Sonata no. 3 in B-minor, op. 58
+      :nodes:
+      - :label: 5:86
+        :proxy: abe9721-5-86.djvu
+      - :label: 5:87
+        :proxy: abe9721-5-87.djvu
+      - :label: 5:88
+        :proxy: abe9721-5-88.djvu
+      - :label: 5:89
+        :proxy: abe9721-5-89.djvu
+    - :label: Barcarolle in F-sharp-major, op. 60
+      :nodes:
+      - :label: 5:90
+        :proxy: abe9721-5-90.djvu
+      - :label: 5:91
+        :proxy: abe9721-5-91.djvu
+    - :label: Polonaise-Fantasie in A-flat-major, op. 61
+      :nodes:
+      - :label: 5:92
+        :proxy: abe9721-5-92.djvu
+      - :label: 5:93
+        :proxy: abe9721-5-93.djvu
+      - :label: 5:94
+        :proxy: abe9721-5-94.djvu
+      - :label: 5:95
+        :proxy: abe9721-5-95.djvu
+    - :label: Sonata in G-minor, for pianoforte and cello, op. 65
+      :nodes:
+      - :label: 5:96
+        :proxy: abe9721-5-96.djvu
+      - :label: 5:97
+        :proxy: abe9721-5-97.djvu
+      - :label: 5:98
+        :proxy: abe9721-5-98.djvu
+      - :label: 5:99
+        :proxy: abe9721-5-99.djvu
+      - :label: 5:100
+        :proxy: abe9721-5-100.djvu
+      - :label: 5:101
+        :proxy: abe9721-5-101.djvu
+      - :label: 5:102
+        :proxy: abe9721-5-102.djvu
+      - :label: 5:103
+        :proxy: abe9721-5-103.djvu
+      - :label: 5:104
+        :proxy: abe9721-5-104.djvu
+      - :label: 5:105
+        :proxy: abe9721-5-105.djvu
+      - :label: 5:106
+        :proxy: abe9721-5-106.djvu
+      - :label: 5:107
+        :proxy: abe9721-5-107.djvu
+      - :label: 5:108
+        :proxy: abe9721-5-108.djvu
+      - :label: 5:109
+        :proxy: abe9721-5-109.djvu
+      - :label: 5:110
+        :proxy: abe9721-5-110.djvu
+      - :label: 5:111
+        :proxy: abe9721-5-111.djvu
+      - :label: 5:112
+        :proxy: abe9721-5-112.djvu
+      - :label: 5:113
+        :proxy: abe9721-5-113.djvu
+    - :label: Mazurka in F-minor, op. 68-4
+      :nodes:
+      - :label: 5:114
+        :proxy: abe9721-5-114.djvu
+      - :label: 5:115
+        :proxy: abe9721-5-115.djvu
+      - :label: 5:116
+        :proxy: abe9721-5-116.djvu
+      - :label: 5:117
+        :proxy: abe9721-5-117.djvu
+      - :label: 5:118
+        :proxy: abe9721-5-118.djvu
+      - :label: 5:119
+        :proxy: abe9721-5-119.djvu
+    - :label: Song for voice and pianoforte, op. 74-6. "Out of my sight!"
+      :nodes:
+      - :label: 5:120
+        :proxy: abe9721-5-120.djvu
+      - :label: 5:121
+        :proxy: abe9721-5-121.djvu
+      - :label: 5:122
+        :proxy: abe9721-5-122.djvu
+      - :label: 5:123
+        :proxy: abe9721-5-123.djvu
+    - :label: Song for voice and pianoforte, op. 74-14. "The ring"
+      :nodes:
+      - :label: 5:124
+        :proxy: abe9721-5-124.djvu
+      - :label: 5:125
+        :proxy: abe9721-5-125.djvu
+      - :label: 5:126
+        :proxy: abe9721-5-126.djvu
+      - :label: 5:127
+        :proxy: abe9721-5-127.djvu
+    - :label: Refrain of "Dabrowski's Mazurka"
+      :nodes:
+      - :label: 5:128
+        :proxy: abe9721-5-128.djvu
+      - :label: 5:129
+        :proxy: abe9721-5-129.djvu
+      - :label: 5:130
+        :proxy: abe9721-5-130.djvu
+      - :label: 5:131
+        :proxy: abe9721-5-131.djvu
+    - :label: Nocturne in C-minor
+      :nodes:
+      - :label: 5:132
+        :proxy: abe9721-5-132.djvu
+      - :label: 5:133
+        :proxy: abe9721-5-133.djvu
+      - :label: 5:134
+        :proxy: abe9721-5-134.djvu
+      - :label: 5:135
+        :proxy: abe9721-5-135.djvu
+    - :label: Sonata no. 2 in B-flat-minor, op. 35
+      :nodes:
+      - :label: 5:136
+        :proxy: abe9721-5-136.djvu
+      - :label: 5:137
+        :proxy: abe9721-5-137.djvu
+    - :label: Impromptu in F-sharp-major, op. 36
+      :nodes:
+      - :label: 5:138
+        :proxy: abe9721-5-138.djvu
+      - :label: 5:139
+        :proxy: abe9721-5-139.djvu
+      - :label: 5:140
+        :proxy: abe9721-5-140.djvu
+      - :label: 5:141
+        :proxy: abe9721-5-141.djvu
+    - :label: Mazurka in G-major, op. 50-1
+      :nodes:
+      - :label: 5:142
+        :proxy: abe9721-5-142.djvu
+      - :label: 5:143
+        :proxy: abe9721-5-143.djvu
+      - :label: "[5:144]"
+        :proxy: abe9721-5-144.djvu
+  - :label: "[Illustrations]"
+    :nodes:
+    - :label: 5:145
+      :proxy: abe9721-5-145.djvu
+    - :label: 5:146
+      :proxy: abe9721-5-146.djvu
+    - :label: 5:147
+      :proxy: abe9721-5-147.djvu
+  - :label: "[Colophon]"
+    :nodes:
+    - :label: "[5:148]"
+      :proxy: abe9721-5-148.djvu
+  :files:
+  - :id: abe9721-5-1.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-1.djvu"
+    :title:
+    - "[5:1]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-2.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-2.djvu"
+    :title:
+    - "[5:2]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-3.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-3.djvu"
+    :title:
+    - "[5:3]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-4.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-4.djvu"
+    :title:
+    - "[5:4]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-5.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-5.djvu"
+    :title:
+    - "[5:5]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-6.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-6.djvu"
+    :title:
+    - "[5:6]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-7.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-7.djvu"
+    :title:
+    - "[5:7]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-8.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-8.djvu"
+    :title:
+    - "[5:8]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-9.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-9.djvu"
+    :title:
+    - "[5:9]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-10.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-10.djvu"
+    :title:
+    - "[5:10]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-11.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-11.djvu"
+    :title:
+    - "[5:11]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-12.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-12.djvu"
+    :title:
+    - "[5:12]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-13.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-13.djvu"
+    :title:
+    - "[5:13]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-14.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-14.djvu"
+    :title:
+    - '5:14'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-15.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-15.djvu"
+    :title:
+    - '5:15'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-16.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-16.djvu"
+    :title:
+    - '5:16'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-17.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-17.djvu"
+    :title:
+    - '5:17'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-18.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-18.djvu"
+    :title:
+    - '5:18'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-19.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-19.djvu"
+    :title:
+    - "[5:19]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-20.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-20.djvu"
+    :title:
+    - '5:20'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-21.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-21.djvu"
+    :title:
+    - '5:21'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-22.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-22.djvu"
+    :title:
+    - '5:22'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-23.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-23.djvu"
+    :title:
+    - '5:23'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-24.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-24.djvu"
+    :title:
+    - '5:24'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-25.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-25.djvu"
+    :title:
+    - '5:25'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-26.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-26.djvu"
+    :title:
+    - '5:26'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-27.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-27.djvu"
+    :title:
+    - '5:27'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-28.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-28.djvu"
+    :title:
+    - '5:28'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-29.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-29.djvu"
+    :title:
+    - '5:29'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-30.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-30.djvu"
+    :title:
+    - '5:30'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-31.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-31.djvu"
+    :title:
+    - '5:31'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-32.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-32.djvu"
+    :title:
+    - '5:32'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-33.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-33.djvu"
+    :title:
+    - '5:33'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-34.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-34.djvu"
+    :title:
+    - '5:34'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-35.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-35.djvu"
+    :title:
+    - '5:35'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-36.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-36.djvu"
+    :title:
+    - '5:36'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-37.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-37.djvu"
+    :title:
+    - '5:37'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-38.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-38.djvu"
+    :title:
+    - '5:38'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-39.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-39.djvu"
+    :title:
+    - '5:39'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-40.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-40.djvu"
+    :title:
+    - '5:40'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-41.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-41.djvu"
+    :title:
+    - '5:41'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-42.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-42.djvu"
+    :title:
+    - '5:42'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-43.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-43.djvu"
+    :title:
+    - '5:43'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-44.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-44.djvu"
+    :title:
+    - '5:44'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-45.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-45.djvu"
+    :title:
+    - '5:45'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-46.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-46.djvu"
+    :title:
+    - '5:46'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-47.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-47.djvu"
+    :title:
+    - '5:47'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-48.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-48.djvu"
+    :title:
+    - '5:48'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-49.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-49.djvu"
+    :title:
+    - '5:49'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-50.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-50.djvu"
+    :title:
+    - '5:50'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-51.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-51.djvu"
+    :title:
+    - '5:51'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-52.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-52.djvu"
+    :title:
+    - '5:52'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-53.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-53.djvu"
+    :title:
+    - '5:53'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-54.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-54.djvu"
+    :title:
+    - '5:54'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-55.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-55.djvu"
+    :title:
+    - '5:55'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-56.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-56.djvu"
+    :title:
+    - '5:56'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-57.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-57.djvu"
+    :title:
+    - '5:57'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-58.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-58.djvu"
+    :title:
+    - '5:58'
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-59.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-59.djvu"
+    :title:
+    - "[5:59]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-60.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-60.djvu"
+    :title:
+    - 5:60
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-61.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-61.djvu"
+    :title:
+    - 5:61
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-62.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-62.djvu"
+    :title:
+    - 5:62
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-63.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-63.djvu"
+    :title:
+    - 5:63
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-64.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-64.djvu"
+    :title:
+    - 5:64
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-65.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-65.djvu"
+    :title:
+    - 5:65
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-66.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-66.djvu"
+    :title:
+    - 5:66
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-67.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-67.djvu"
+    :title:
+    - 5:67
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-68.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-68.djvu"
+    :title:
+    - 5:68
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-69.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-69.djvu"
+    :title:
+    - 5:69
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-70.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-70.djvu"
+    :title:
+    - 5:70
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-71.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-71.djvu"
+    :title:
+    - 5:71
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-72.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-72.djvu"
+    :title:
+    - 5:72
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-73.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-73.djvu"
+    :title:
+    - 5:73
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-74.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-74.djvu"
+    :title:
+    - 5:74
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-75.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-75.djvu"
+    :title:
+    - 5:75
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-76.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-76.djvu"
+    :title:
+    - "[5:76]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-77.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-77.djvu"
+    :title:
+    - "[5:77]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-78.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-78.djvu"
+    :title:
+    - 5:78
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-79.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-79.djvu"
+    :title:
+    - 5:79
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-80.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-80.djvu"
+    :title:
+    - 5:80
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-81.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-81.djvu"
+    :title:
+    - 5:81
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-82.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-82.djvu"
+    :title:
+    - 5:82
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-83.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-83.djvu"
+    :title:
+    - 5:83
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-84.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-84.djvu"
+    :title:
+    - 5:84
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-85.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-85.djvu"
+    :title:
+    - 5:85
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-86.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-86.djvu"
+    :title:
+    - 5:86
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-87.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-87.djvu"
+    :title:
+    - 5:87
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-88.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-88.djvu"
+    :title:
+    - 5:88
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-89.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-89.djvu"
+    :title:
+    - 5:89
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-90.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-90.djvu"
+    :title:
+    - 5:90
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-91.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-91.djvu"
+    :title:
+    - 5:91
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-92.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-92.djvu"
+    :title:
+    - 5:92
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-93.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-93.djvu"
+    :title:
+    - 5:93
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-94.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-94.djvu"
+    :title:
+    - 5:94
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-95.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-95.djvu"
+    :title:
+    - 5:95
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-96.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-96.djvu"
+    :title:
+    - 5:96
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-97.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-97.djvu"
+    :title:
+    - 5:97
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-98.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-98.djvu"
+    :title:
+    - 5:98
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-99.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-99.djvu"
+    :title:
+    - 5:99
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-100.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-100.djvu"
+    :title:
+    - 5:100
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-101.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-101.djvu"
+    :title:
+    - 5:101
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-102.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-102.djvu"
+    :title:
+    - 5:102
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-103.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-103.djvu"
+    :title:
+    - 5:103
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-104.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-104.djvu"
+    :title:
+    - 5:104
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-105.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-105.djvu"
+    :title:
+    - 5:105
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-106.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-106.djvu"
+    :title:
+    - 5:106
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-107.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-107.djvu"
+    :title:
+    - 5:107
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-108.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-108.djvu"
+    :title:
+    - 5:108
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-109.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-109.djvu"
+    :title:
+    - 5:109
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-110.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-110.djvu"
+    :title:
+    - 5:110
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-111.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-111.djvu"
+    :title:
+    - 5:111
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-112.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-112.djvu"
+    :title:
+    - 5:112
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-113.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-113.djvu"
+    :title:
+    - 5:113
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-114.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-114.djvu"
+    :title:
+    - 5:114
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-115.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-115.djvu"
+    :title:
+    - 5:115
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-116.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-116.djvu"
+    :title:
+    - 5:116
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-117.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-117.djvu"
+    :title:
+    - 5:117
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-118.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-118.djvu"
+    :title:
+    - 5:118
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-119.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-119.djvu"
+    :title:
+    - 5:119
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-120.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-120.djvu"
+    :title:
+    - 5:120
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-121.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-121.djvu"
+    :title:
+    - 5:121
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-122.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-122.djvu"
+    :title:
+    - 5:122
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-123.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-123.djvu"
+    :title:
+    - 5:123
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-124.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-124.djvu"
+    :title:
+    - 5:124
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-125.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-125.djvu"
+    :title:
+    - 5:125
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-126.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-126.djvu"
+    :title:
+    - 5:126
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-127.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-127.djvu"
+    :title:
+    - 5:127
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-128.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-128.djvu"
+    :title:
+    - 5:128
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-129.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-129.djvu"
+    :title:
+    - 5:129
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-130.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-130.djvu"
+    :title:
+    - 5:130
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-131.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-131.djvu"
+    :title:
+    - 5:131
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-132.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-132.djvu"
+    :title:
+    - 5:132
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-133.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-133.djvu"
+    :title:
+    - 5:133
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-134.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-134.djvu"
+    :title:
+    - 5:134
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-135.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-135.djvu"
+    :title:
+    - 5:135
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-136.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-136.djvu"
+    :title:
+    - 5:136
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-137.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-137.djvu"
+    :title:
+    - 5:137
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-138.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-138.djvu"
+    :title:
+    - 5:138
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-139.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-139.djvu"
+    :title:
+    - 5:139
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-140.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-140.djvu"
+    :title:
+    - 5:140
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-141.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-141.djvu"
+    :title:
+    - 5:141
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-142.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-142.djvu"
+    :title:
+    - 5:142
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-143.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-143.djvu"
+    :title:
+    - 5:143
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-144.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-144.djvu"
+    :title:
+    - "[5:144]"
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-145.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-145.djvu"
+    :title:
+    - 5:145
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-146.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-146.djvu"
+    :title:
+    - 5:146
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-147.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-147.djvu"
+    :title:
+    - 5:147
+    :replaces: replaces
+    :file_opts: {}
+  - :id: abe9721-5-148.djvu
+    :checksum: ''
+    :mime_type: image/tiff
+    :path: "/tmp/MS-METS/bhr9405/abe9721-5-148.djvu"
+    :title:
+    - "[5:148]"
+    :replaces: replaces
+    :file_opts: {}
+:source:
+  :title:
+  - Variations XML
+  :file: spec/fixtures/variations_xml/abe9721.xml

--- a/spec/fixtures/variations_xml/bhr9405.xml
+++ b/spec/fixtures/variations_xml/bhr9405.xml
@@ -1,0 +1,261 @@
+<ScoreAccessPage>
+  <HtmlPageStatus>None</HtmlPageStatus>
+  <Bibinfo>
+    <StmtResponsibility>di Ottorino Respighi</StmtResponsibility>
+    <Author>Respighi, Ottorino, 1879-1936</Author>
+  </Bibinfo>
+
+<RecordSet version="trunk">
+   <Container>
+      <DisplayTitle offset="0">Fontane di Roma ; poema sinfonico per orchestra</DisplayTitle>
+      <AdditionalTitles/>
+      <SeriesTitles/>
+      <Publisher>G. Ricordi</Publisher>
+      <Edition/>
+      <PublisherNumbers>
+         <PublisherNumber>G. Ricordi:P.R.206</PublisherNumber>
+      </PublisherNumbers>
+      <DocumentInfos>
+         <DocumentInfo>
+            <Type>Score</Type>
+            <Format>Full Score</Format>
+            <Description>1 score (64 p.) ; 32 cm</Description>
+         </DocumentInfo>
+      </DocumentInfos>
+      <Languages>
+         <Language>
+            <Context>Notes</Context>
+            <Language>English</Language>
+         </Language>
+         <Language>
+            <Context>Notes</Context>
+            <Language>German</Language>
+         </Language>
+         <Language>
+            <Context>Notes</Context>
+            <Language>German</Language>
+         </Language>
+         <Language>
+            <Context>Notes</Context>
+            <Language>French</Language>
+         </Language>
+      </Languages>
+      <PublicationDate>1947, c1918</PublicationDate>
+      <CopyrightDate/>
+      <PublicationPlace>Milano ; New York</PublicationPlace>
+      <BibliographicNotes>
+         <BibliographicNote>
+            <Type>Descriptive</Type>
+            <Text>BM: 900615</Text>
+         </BibliographicNote>
+         <BibliographicNote>
+            <Type>Descriptive</Type>
+            <Text>BM: 900615</Text>
+         </BibliographicNote>
+      </BibliographicNotes>
+      <Structure label="Fontane di Roma ; poema sinfonico per orchestra">
+         <Item label="Fontane di Roma ; poema sinfonico per orchestra">
+            <Div label="[Title Page and Copyright Page]">
+               <Chunk label="[i]">
+                  <ContentInterval begin="0" end="1" mediaRef="IU/MediaObject/404811"/>
+               </Chunk>
+               <Chunk label="[ii]">
+                  <ContentInterval begin="1" end="2" mediaRef="IU/MediaObject/404811"/>
+               </Chunk>
+            </Div>
+            <Div label="[Notes]">
+               <Chunk label="[iii]">
+                  <ContentInterval begin="2" end="3" mediaRef="IU/MediaObject/404811"/>
+               </Chunk>
+               <Chunk label="[iv]">
+                  <ContentInterval begin="3" end="4" mediaRef="IU/MediaObject/404811"/>
+               </Chunk>
+            </Div>
+            <Div label="[Orchestration]">
+               <Chunk label="[v]">
+                  <ContentInterval begin="4" end="5" mediaRef="IU/MediaObject/404811"/>
+               </Chunk>
+               <Chunk label="[vi]">
+                  <ContentInterval begin="5" end="6" mediaRef="IU/MediaObject/404811"/>
+               </Chunk>
+            </Div>
+            <Div label="Fontane de Roma : Poema Sinfonico">
+               <Div label="La fontana di Valle Giulia all'alba">
+                  <Chunk label="1">
+                     <ContentInterval begin="6" end="7" mediaRef="IU/MediaObject/404811"/>
+                  </Chunk>
+                  <Chunk label="2">
+                     <ContentInterval begin="7" end="8" mediaRef="IU/MediaObject/404811"/>
+                  </Chunk>
+                  <Chunk label="3">
+                     <ContentInterval begin="8" end="9" mediaRef="IU/MediaObject/404811"/>
+                  </Chunk>
+                  <Chunk label="4">
+                     <ContentInterval begin="9" end="10" mediaRef="IU/MediaObject/404811"/>
+                  </Chunk>
+               </Div>
+            </Div>
+         </Item>
+      </Structure>
+      <Contributions/>
+      <InstantiationRefs>
+         <InstantiationRef>IU/Instantiation/432532</InstantiationRef>
+      </InstantiationRefs>
+      <MediaObjectRefs>
+         <MediaObjectRef>IU/MediaObject/404811</MediaObjectRef>
+      </MediaObjectRefs>
+      <PhysicalID>
+         <Location>IU Music Library</Location>
+         <CallNumber>M1002.R434 F6 R5 1947</CallNumber>
+         <CopyNumber>1</CopyNumber>
+      </PhysicalID>
+      <PhysicalCondition/>
+      <HoldingStatus>Publicly available</HoldingStatus>
+      <Isbn/>
+      <Upc/>
+      <Ismn/>
+      <CopyrightDecls>
+         <CopyrightDecl>
+            <Owner>G. Ricordi &amp; Co.</Owner>
+            <Domain>Container</Domain>
+            <Date>1918</Date>
+         </CopyrightDecl>
+      </CopyrightDecls>
+      <PublicDomain>Unknown</PublicDomain>
+      <OtherSystemIds>
+         <OtherSystemId>(Variations)bhr9405</OtherSystemId>
+         <OtherSystemId>(InU)BHR9405BM</OtherSystemId>
+         <OtherSystemId>(OCoLC)ocm09430539</OtherSystemId>
+      </OtherSystemIds>
+      <Id>IU/Container/404807</Id>
+      <CreationInfo>
+         <User>epeebles@IU.EDU</User>
+         <Timestamp>2007-11-14 15:46:00.0</Timestamp>
+      </CreationInfo>
+      <UpdateInfo>
+         <User>schmiecs@IU.EDU</User>
+         <Timestamp>2012-06-25 15:30:20.869</Timestamp>
+      </UpdateInfo>
+      <Status>Minimal</Status>
+   </Container>
+   <MediaObject>
+      <Label>BHR9405</Label>
+      <FileFormat>image/tiff</FileFormat>
+      <Compression/>
+      <BitDepth/>
+      <Resolution/>
+      <ChannelCount>0</ChannelCount>
+      <SampleSize>0</SampleSize>
+      <SampleRate>0</SampleRate>
+      <Environment>Fujitsu Model fi4750C</Environment>
+      <DigitizationDate>2007-11-14</DigitizationDate>
+      <DigitizedBy>epeebles@IU.EDU</DigitizedBy>
+      <AccessCount>0</AccessCount>
+      <FileInfos>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>bhr9405-1-1.tif</FileName>
+            <Checksum>FXJcA+AOLEWfKLZgr/g/Lw==</Checksum>
+            <Creation>2008-08-29 12:09:46.0</Creation>
+            <Update>2008-08-29 12:09:46.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>bhr9405-1-2.tif</FileName>
+            <Checksum>o/mDr11aicH0dTlGK7yeNA==</Checksum>
+            <Creation>2008-08-29 12:09:46.0</Creation>
+            <Update>2008-08-29 12:09:46.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>bhr9405-1-3.tif</FileName>
+            <Checksum>grASE1rVo1Dh+XZw7HcQzw==</Checksum>
+            <Creation>2008-08-29 12:09:46.0</Creation>
+            <Update>2008-08-29 12:09:46.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>bhr9405-1-4.tif</FileName>
+            <Checksum>n4b9UqMsf+lXANkkCM9/hw==</Checksum>
+            <Creation>2008-08-29 12:09:46.0</Creation>
+            <Update>2008-08-29 12:09:46.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>bhr9405-1-5.tif</FileName>
+            <Checksum>ruFuWxuwMzf66fdIvoqbkg==</Checksum>
+            <Creation>2008-08-29 12:09:46.0</Creation>
+            <Update>2008-08-29 12:09:46.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>bhr9405-1-6.tif</FileName>
+            <Checksum>HPW1qrX4MyWlYSZ3TDtGXA==</Checksum>
+            <Creation>2008-08-29 12:09:46.0</Creation>
+            <Update>2008-08-29 12:09:46.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>bhr9405-1-7.tif</FileName>
+            <Checksum>OcBMJjWQsheavWqDSHvx5Q==</Checksum>
+            <Creation>2008-08-29 12:09:46.0</Creation>
+            <Update>2008-08-29 12:09:46.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>bhr9405-1-8.tif</FileName>
+            <Checksum>x68xNkVnDbojZn788OFDyg==</Checksum>
+            <Creation>2008-08-29 12:09:46.0</Creation>
+            <Update>2008-08-29 12:09:46.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>bhr9405-1-9.tif</FileName>
+            <Checksum>/BrnLNGlEQx59yEA+fe6dQ==</Checksum>
+            <Creation>2008-08-29 12:09:46.0</Creation>
+            <Update>2008-08-29 12:09:46.0</Update>
+         </FileInfo>
+         <FileInfo>
+            <Extent>1</Extent>
+            <Size>0</Size>
+            <FileName>bhr9405-1-10.tif</FileName>
+            <Checksum>u7NBZSu1bN36Hdg4cfBhTg==</Checksum>
+            <Creation>2008-08-29 12:09:46.0</Creation>
+            <Update>2008-08-29 12:09:46.0</Update>
+         </FileInfo>
+      </FileInfos>
+      <Id>IU/MediaObject/404811</Id>
+      <CreationInfo>
+         <User>epeebles@IU.EDU</User>
+         <Timestamp>2007-11-14 15:56:16.0</Timestamp>
+      </CreationInfo>
+      <UpdateInfo>
+         <User>schmiecs@IU.EDU</User>
+         <Timestamp>2012-06-25 15:30:20.0</Timestamp>
+      </UpdateInfo>
+      <Status>Complete</Status>
+   </MediaObject>
+   <SetInfo>
+      <TextMatches/>
+      <ThemeBaseURL>http://variations-prod-web.dlib.indiana.edu/variations/themes/</ThemeBaseURL>
+      <AvailableMediaItems>
+         <AllItemsAvailable>true</AllItemsAvailable>
+      </AvailableMediaItems>
+   </SetInfo>
+</RecordSet>
+
+<AccompanyingMaterials>
+
+</AccompanyingMaterials>
+
+
+</ScoreAccessPage>

--- a/spec/fixtures/variations_xml/bhr9405.yml
+++ b/spec/fixtures/variations_xml/bhr9405.yml
@@ -1,0 +1,123 @@
+---
+:identifier: identifier
+:replaces: replaces
+:source_metadata_identifier: BHR9405
+:viewing_direction: right-to-left
+:thumbnail_path: "/tmp/MS-METS/bhr9405/bhr9405-1-1.tif"
+:structure:
+  :nodes:
+  - :label: "[Title Page and Copyright Page]"
+    :nodes:
+    - :label: "[i]"
+      :proxy: bhr9405-1-1.tif
+    - :label: "[ii]"
+      :proxy: bhr9405-1-2.tif
+  - :label: "[Notes]"
+    :nodes:
+    - :label: "[iii]"
+      :proxy: bhr9405-1-3.tif
+    - :label: "[iv]"
+      :proxy: bhr9405-1-4.tif
+  - :label: "[Orchestration]"
+    :nodes:
+    - :label: "[v]"
+      :proxy: bhr9405-1-5.tif
+    - :label: "[vi]"
+      :proxy: bhr9405-1-6.tif
+  - :label: 'Fontane de Roma : Poema Sinfonico'
+    :nodes:
+    - :label: La fontana di Valle Giulia all'alba
+      :nodes:
+      - :label: '1'
+        :proxy: bhr9405-1-7.tif
+      - :label: '2'
+        :proxy: bhr9405-1-8.tif
+      - :label: '3'
+        :proxy: bhr9405-1-9.tif
+      - :label: '4'
+        :proxy: bhr9405-1-10.tif
+:files:
+- :id: bhr9405-1-1.tif
+  :checksum: FXJcA+AOLEWfKLZgr/g/Lw==
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-1.tif"
+  :title:
+  - "[i]"
+  :replaces: replaces
+  :file_opts: {}
+- :id: bhr9405-1-2.tif
+  :checksum: o/mDr11aicH0dTlGK7yeNA==
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-2.tif"
+  :title:
+  - "[ii]"
+  :replaces: replaces
+  :file_opts: {}
+- :id: bhr9405-1-3.tif
+  :checksum: grASE1rVo1Dh+XZw7HcQzw==
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-3.tif"
+  :title:
+  - "[iii]"
+  :replaces: replaces
+  :file_opts: {}
+- :id: bhr9405-1-4.tif
+  :checksum: n4b9UqMsf+lXANkkCM9/hw==
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-4.tif"
+  :title:
+  - "[iv]"
+  :replaces: replaces
+  :file_opts: {}
+- :id: bhr9405-1-5.tif
+  :checksum: ruFuWxuwMzf66fdIvoqbkg==
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-5.tif"
+  :title:
+  - "[v]"
+  :replaces: replaces
+  :file_opts: {}
+- :id: bhr9405-1-6.tif
+  :checksum: HPW1qrX4MyWlYSZ3TDtGXA==
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-6.tif"
+  :title:
+  - "[vi]"
+  :replaces: replaces
+  :file_opts: {}
+- :id: bhr9405-1-7.tif
+  :checksum: OcBMJjWQsheavWqDSHvx5Q==
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-7.tif"
+  :title:
+  - '1'
+  :replaces: replaces
+  :file_opts: {}
+- :id: bhr9405-1-8.tif
+  :checksum: x68xNkVnDbojZn788OFDyg==
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-8.tif"
+  :title:
+  - '2'
+  :replaces: replaces
+  :file_opts: {}
+- :id: bhr9405-1-9.tif
+  :checksum: "/BrnLNGlEQx59yEA+fe6dQ=="
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-9.tif"
+  :title:
+  - '3'
+  :replaces: replaces
+  :file_opts: {}
+- :id: bhr9405-1-10.tif
+  :checksum: u7NBZSu1bN36Hdg4cfBhTg==
+  :mime_type: image/tiff
+  :path: "/tmp/MS-METS/bhr9405/bhr9405-1-10.tif"
+  :title:
+  - '4'
+  :replaces: replaces
+  :file_opts: {}
+:source:
+  :title:
+  - Variations XML
+  :file: spec/fixtures/variations_xml/bhr9405.xml


### PR DESCRIPTION
### Overview

This is a conceptual demonstration of 2-stage preingest/ingest for Variations XML, intended to facilitate discussion of how we might support direct file ingest of Variations, ContentDM content.  We may prefer to run single-stage ingest rather than preingest+ingest, but this should inform the tasks needed to be met in order to do that.

Included to play with is a fudged version of bhr9405.xml:
- It has been shortened to 10 pages, so it's not unwieldy
- the .djvu file references have been changed to .tif, and the location changed to /tmp/MS-METS/bhr9405/
  It does not include the 10 image files, so to actually run ingest, you will need to provide them in (or copy them to) the specified tmp folder.
### Use

You can run the Variations->YAML preingest, then YAML ingest, with the following:

``` sh
rake preingest_variations spec/fixtures/variations_xml
rake ingest_yaml spec/fixtures/variations_xml
```
### Notes

The Variations preingest does actually read the logical structure, which (in theory) is the heaviest lifting to do.  (It does not yet handle multi-volume works, and the structural logic for single-volume works has not been robustly tested and likely needs revision.)  Some other things are presently heavily fudged:
- the file path
- the right-to-left/left-to-right viewing_direction value
- :identifier and :replaces values; I'm not sure in our IU context if we actually need these in addition to :source_metadata_identifier
- file_opts (always blank; needs logic to provide viewing_hint: 'non-paged' when applicable)
### More notes
- I haven't tried it, but given that file locations are fully-qualified URIs (file:///...), ingest may already handle remote files, out-of-the-box?
- Currently, both preingest and ingest have awareness of the user and collections arguments (although, only ingest is actually using them).  If we do go with 2-stage preingest+ingest, I'm drawn to the idea of making ingest maximally simple, so these arguments would only apply to preingest and the results would be saved in the YAML (or equivalent) used for ingest.  But there may be other considerations here I'm not realizing.
