### PR TITLE
Experiment: ingesting ordered_members associations for FileSets in batch (or not at all)

### DIFF
--- a/app/jobs/ingest_yaml_job.rb
+++ b/app/jobs/ingest_yaml_job.rb
@@ -1,14 +1,17 @@
 class IngestYAMLJob < ActiveJob::Base
   include CollectionHelper
+  include CurationConcerns::Lockable
+
   queue_as :ingest
 
   # @param [String] yaml_file Filename of a YAML file to ingest
   # @param [String] user User to ingest as
-  def perform(yaml_file, user)
+  def perform(yaml_file, user, file_association_method: 'individual')
     logger.info "Ingesting YAML #{yaml_file}"
     @yaml_file = yaml_file
     @yaml = File.open(yaml_file) { |f| Psych.load(f) }
     @user = user
+    @file_association_method = file_association_method
     ingest
   end
 
@@ -78,22 +81,37 @@ class IngestYAMLJob < ActiveJob::Base
       end
     end
 
+# FIXME: check that setting membership also sets member_of on child
     def ingest_files(parent: nil, resource: nil, files: [])
+      @file_sets = []
       files.each do |f|
         logger.info "Ingesting file #{f[:path]}"
         @counter.increment
         file_set = FileSet.new
         file_set.attributes = f[:attributes]
+        copy_visibility(resource, file_set) unless assign_visibility?(f[:attributes])
         actor = FileSetActor.new(file_set, @user)
-        actor.create_metadata(resource, f[:file_opts])
+        if @file_association_method.in? ['batch', 'none']
+          actor.create_metadata(nil, f[:file_opts])
+        else
+          actor.create_metadata(resource, f[:file_opts])
+        end
         actor.create_content(decorated_file(f))
 
         yaml_to_repo_map[f[:id]] = file_set.id
+        @file_sets << file_set
 
+        # FIXME: add representative association, along with thumbnail?
         next unless f[:path] == thumbnail_path
         resource.thumbnail_id = file_set.id
         resource.save!
         parent.thumbnail_id = file_set.id if parent
+        # FIXME: save parent?  add representative?
+      end
+      if @file_association_method == 'batch'
+        logger.info "Starting batch file_set association"
+        attach_files_to_work(resource, @file_sets)
+        logger.info "Completed batch file_set association"
       end
     end
 
@@ -115,4 +133,39 @@ class IngestYAMLJob < ActiveJob::Base
     def thumbnail_path
       @thumbnail_path ||= @yaml[:thumbnail_path]
     end
+
+    # TESTING
+        def attach_files_to_work(work, file_sets)
+          acquire_lock_for(work.id) do
+            set_representative(work, file_sets.first) if file_sets.any?
+            set_thumbnail(work, file_sets.first) if file_sets.any?
+            # Ensure we have an up-to-date copy of the members association, so
+            # that we append to the end of the list.
+            work.reload unless work.new_record?
+            work.ordered_members = file_sets
+
+            # Save the work so the association between the work and the file_set is persisted (head_id)
+            work.save! # FIXME: added !
+          end
+        end
+
+        def assign_visibility?(file_set_params = {})
+          !((file_set_params || {}).keys & %w(visibility embargo_release_date lease_expiration_date)).empty?
+        end
+
+        # copy visibility from source_concern to destination_concern
+        def copy_visibility(source_concern, destination_concern)
+          destination_concern.visibility = source_concern.visibility
+        end
+
+        def set_representative(work, file_set)
+          return unless work.representative_id.blank?
+          work.representative = file_set
+        end
+
+        def set_thumbnail(work, file_set)
+          return unless work.thumbnail_id.blank?
+          work.thumbnail = file_set
+        end
+
 end

--- a/lib/tasks/ingest_yaml.rake
+++ b/lib/tasks/ingest_yaml.rake
@@ -15,7 +15,9 @@ namespace :pmp do
     logger.info "ingesting as: #{user.user_key} (override with USER=foo)"
 
     begin
-      IngestYAMLJob.perform_now(file, user)
+      file_association_method = ENV['FILE_ASSOCIATION_METHOD'] || 'individual'
+      logger.info "ingesting with file association method: #{file_association_method} (override with FILE_ASSOCIATION_METHOD=individual|batch|none)"
+      IngestYAMLJob.perform_now(file, user, file_association_method: file_association_method)
     rescue => e
       logger.info "Error: #{e.message}"
       logger.info e.backtrace


### PR DESCRIPTION
Running ingest with this environment variable set (or, none at all) should produce the same ingest behavior we've had:

    $ bundle exec rake pmp:ingest spec/fixtures/variations_xml/bhr9405.yml \
      FILE_ASSOCIATION_METHOD=individual

Setting a 'none' value should retain the structural manifest, but completely abandon the individual file_set -> scanned_resource association that powers the index.  (We probably want to retain that, but it can provide a point of comparison.)

    $ bundle exec rake pmp:ingest spec/fixtures/variations_xml/bhr9405.yml \
      FILE_ASSOCIATION_METHOD=none

Setting a "batch" value should produce the same end result as normal, but sets the ordered_members association just once, in batch, for all files.  This should provide a performance comparison vs. incrementally adding individual file_sets to ordered membership.

    $ bundle exec rake pmp:ingest spec/fixtures/variations_xml/bhr9405.yml \ 
      FILE_ASSOCIATION_METHOD=batch